### PR TITLE
Fix port inconsistencies in documentation and verify-setup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ sudo systemctl start mysql
    npm run dev
    ```
 
-   This starts the frontend at `http://localhost:3000`
+   This starts the frontend at `http://localhost:2460`
 
    **Terminal 2 - Backend (PHP server):**
 
@@ -143,7 +143,7 @@ sudo systemctl start mysql
 
 5. **Open your browser**
 
-   Navigate to `http://localhost:3000`
+   Navigate to `http://localhost:2460`
 
    The Vite dev server automatically proxies API requests from `/api` to the PHP backend.
 

--- a/src/api/SETUP.md
+++ b/src/api/SETUP.md
@@ -145,9 +145,9 @@ All test users have simple passwords for development:
 
 Try these ballot keys to see the app in action:
 
-- Visit: `http://localhost:3000/?key=pizza` - 🍕 Best Pizza Flavor
-- Visit: `http://localhost:3000/?key=codelang` - 💻 Programming Languages
-- Visit: `http://localhost:3000/?key=council2024` - 🏛️ City Council Election
+- Visit: `http://localhost:2460/?key=pizza` - 🍕 Best Pizza Flavor
+- Visit: `http://localhost:2460/?key=codelang` - 💻 Programming Languages
+- Visit: `http://localhost:2460/?key=council2024` - 🏛️ City Council Election
 
 ## Troubleshooting
 
@@ -208,6 +208,6 @@ Once the database is set up:
 
 1. Run `npm install` to install dependencies
 2. Run `npm run dev` to start the Vite dev server
-3. In another terminal, run `cd src && php -S localhost:8000` for the PHP backend
-4. Visit `http://localhost:3000`
+3. In another terminal, run `cd src && php -S localhost:2461` for the PHP backend
+4. Visit `http://localhost:2460`
 5. Create an account and test ballot creation

--- a/verify-setup.sh
+++ b/verify-setup.sh
@@ -108,8 +108,8 @@ check_port() {
     fi
 }
 
-check_port 3000 "Vite dev server"
-check_port 8000 "PHP backend API"
+check_port 2460 "Vite dev server"
+check_port 2461 "PHP backend API"
 
 # Check project files
 echo ""
@@ -198,8 +198,8 @@ if [ $ERRORS -eq 0 ] && [ $WARNINGS -eq 0 ]; then
     echo ""
     echo "  Development mode (recommended):"
     echo "    Terminal 1: npm run dev"
-    echo "    Terminal 2: cd src && php -S localhost:8000"
-    echo "    Then visit: http://localhost:3000"
+    echo "    Terminal 2: cd src && php -S localhost:2461"
+    echo "    Then visit: http://localhost:2460"
     echo ""
     echo "  Production build:"
     echo "    npm run build"


### PR DESCRIPTION
The Vite dev server is configured to port 2460 in vite.config.js, and the
PHP backend proxy target is 2461. However, three files contained stale port
references (3000 for the frontend, 8000 for the PHP backend) that would
mislead other developers following the setup instructions.

## Changes

- **README.md**: Update "open your browser" URL from `localhost:3000` to `localhost:2460`
- **src/api/SETUP.md**: Fix "Next Steps" section — PHP backend command from
  `localhost:8000` → `localhost:2461`, and visit URL from `localhost:3000` → `localhost:2460`;
  also fix Quick Test Ballot links (3 URLs)
- **verify-setup.sh**: Fix check_port calls (3000→2460, 8000→2461) and the
  success summary message

## How to verify

Run `bash verify-setup.sh` — the port availability checks will now match the
ports actually used by the dev servers.