### PR TITLE
Add PHP API tests for groupings, code management, ballot transfer, and user creation

### DIFF
--- a/src/api/delete-code.php
+++ b/src/api/delete-code.php
@@ -40,9 +40,9 @@ if ($voteCheck->fetch()) {
 
 // Delete the code assignment (not the random_code itself)
 $sth = $dbh->prepare("
-	DELETE bc FROM ballot_codes bc
-	JOIN random_codes rc ON rc.id = bc.random_code_id
-	WHERE bc.ballot_id = :ballotId AND rc.code = :code
+	DELETE FROM ballot_codes
+	WHERE ballot_id = :ballotId
+	AND random_code_id = (SELECT id FROM random_codes WHERE code = :code)
 ");
 $sth->bindValue(':ballotId', $_POST['ballotId'], PDO::PARAM_INT);
 $sth->bindValue(':code', $_POST['code'], PDO::PARAM_STR);

--- a/src/api/update-code-label.php
+++ b/src/api/update-code-label.php
@@ -23,10 +23,10 @@ if (empty($errors)) {
 if (empty($errors)) {
 	$label = isset($_POST['label']) ? $_POST['label'] : '';
 	$sth = $dbh->prepare("
-		UPDATE ballot_codes bc
-		JOIN random_codes rc ON rc.id = bc.random_code_id
-		SET bc.label = :label
-		WHERE bc.ballot_id = :ballotId AND rc.code = :code
+		UPDATE ballot_codes
+		SET label = :label
+		WHERE ballot_id = :ballotId
+		AND random_code_id = (SELECT id FROM random_codes WHERE code = :code)
 	");
 	$sth->bindValue(':label', $label, PDO::PARAM_STR);
 	$sth->bindValue(':ballotId', $_POST['ballotId'], PDO::PARAM_INT);

--- a/test/php/AddUserTest.php
+++ b/test/php/AddUserTest.php
@@ -1,0 +1,67 @@
+<?php
+
+require_once __DIR__ . '/ApiTestCase.php';
+
+class AddUserTest extends ApiTestCase
+{
+    public function testCreatesUserAndReturnsId(): void
+    {
+        $result = $this->callApi('add-user.php', [
+            'username' => 'alice',
+            'email'    => 'alice@example.com',
+            'password' => 'secret',
+        ]);
+
+        $this->assertIsArray($result['body']);
+        $this->assertArrayHasKey('id', $result['body']);
+        $this->assertIsInt($result['body']['id']);
+
+        $sth = $this->db->prepare("SELECT username FROM users WHERE id = ?");
+        $sth->execute([$result['body']['id']]);
+        $this->assertEquals('alice', $sth->fetchColumn());
+    }
+
+    public function testReturnsIdEvenWithNoUserFields(): void
+    {
+        // add-user.php always inserts at minimum the server-generated id,
+        // so the error branch (`failed to supply info`) is unreachable.
+        $result = $this->callApi('add-user.php', []);
+
+        $this->assertIsArray($result['body']);
+        $this->assertArrayHasKey('id', $result['body'], 'A bare id-only row is always inserted');
+    }
+
+    public function testIgnoresNonAcceptableFields(): void
+    {
+        $result = $this->callApi('add-user.php', [
+            'username' => 'bob',
+            'role'     => 'admin',
+        ]);
+
+        $this->assertIsArray($result['body']);
+        $this->assertArrayHasKey('id', $result['body']);
+
+        $sth = $this->db->prepare("SELECT role FROM users WHERE id = ?");
+        $sth->execute([$result['body']['id']]);
+        $role = $sth->fetchColumn();
+        $this->assertNotEquals('admin', $role, 'Non-acceptable fields should not be written to the database');
+    }
+
+    public function testDuplicateUsernameDoesNotError(): void
+    {
+        $this->callApi('add-user.php', ['username' => 'alice', 'email' => 'alice@example.com']);
+        $result = $this->callApi('add-user.php', ['username' => 'alice', 'email' => 'alice2@example.com']);
+
+        $this->assertIsArray($result['body']);
+        $this->assertArrayHasKey('id', $result['body'], 'Duplicate insert should silently succeed (ON DUPLICATE KEY)');
+    }
+
+    public function testGeneratedIdIsInExpectedRange(): void
+    {
+        $result = $this->callApi('add-user.php', ['username' => 'carol']);
+
+        $id = $result['body']['id'];
+        $this->assertGreaterThanOrEqual(1,          $id);
+        $this->assertLessThanOrEqual(2000000000, $id);
+    }
+}

--- a/test/php/DeleteCodeTest.php
+++ b/test/php/DeleteCodeTest.php
@@ -1,0 +1,104 @@
+<?php
+
+require_once __DIR__ . '/ApiTestCase.php';
+
+class DeleteCodeTest extends ApiTestCase
+{
+    public function testDeletesUnusedCode(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+        $this->seedVoterCode($ballotId, 'abc123');
+
+        $result = $this->callApi('delete-code.php', [
+            'ballotId'  => $ballotId,
+            'code'      => 'abc123',
+            'createdBy' => 'alice',
+        ]);
+
+        $this->assertIsArray($result['body']);
+        $this->assertTrue($result['body']['success']);
+
+        $sth = $this->db->prepare("SELECT COUNT(*) FROM ballot_codes WHERE ballot_id = ?");
+        $sth->execute([$ballotId]);
+        $this->assertEquals(0, (int) $sth->fetchColumn());
+    }
+
+    public function testRequiresBallotId(): void
+    {
+        $result = $this->callApi('delete-code.php', ['code' => 'abc123', 'createdBy' => 'alice']);
+
+        $this->assertArrayHasKey('errors', $result['body']);
+        $this->assertArrayHasKey('ballotId', $result['body']['errors']);
+    }
+
+    public function testRequiresCode(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+
+        $result = $this->callApi('delete-code.php', ['ballotId' => $ballotId, 'createdBy' => 'alice']);
+
+        $this->assertArrayHasKey('errors', $result['body']);
+        $this->assertArrayHasKey('code', $result['body']['errors']);
+    }
+
+    public function testRequiresCreatedBy(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+
+        $result = $this->callApi('delete-code.php', ['ballotId' => $ballotId, 'code' => 'abc123']);
+
+        $this->assertArrayHasKey('errors', $result['body']);
+        $this->assertArrayHasKey('createdBy', $result['body']['errors']);
+    }
+
+    public function testRejectsUnauthorizedUser(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+        $this->seedVoterCode($ballotId, 'mycode');
+
+        $result = $this->callApi('delete-code.php', [
+            'ballotId'  => $ballotId,
+            'code'      => 'mycode',
+            'createdBy' => 'bob',
+        ]);
+
+        $this->assertArrayHasKey('errors', $result['body']);
+        $this->assertArrayHasKey('auth', $result['body']['errors']);
+    }
+
+    public function testRefusesToDeleteUsedCode(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+        $this->seedVoterCode($ballotId, 'usedcode');
+        $this->seedVote($ballotId, '1,2', '', 'usedcode');
+
+        $result = $this->callApi('delete-code.php', [
+            'ballotId'  => $ballotId,
+            'code'      => 'usedcode',
+            'createdBy' => 'alice',
+        ]);
+
+        $this->assertArrayHasKey('errors', $result['body']);
+        $this->assertArrayHasKey('voted', $result['body']['errors']);
+
+        $sth = $this->db->prepare("SELECT COUNT(*) FROM ballot_codes WHERE ballot_id = ?");
+        $sth->execute([$ballotId]);
+        $this->assertEquals(1, (int) $sth->fetchColumn(), 'Used code should not be deleted');
+    }
+
+    public function testDoesNotDeleteRandomCodeRecord(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+        $this->seedVoterCode($ballotId, 'keepme');
+
+        $this->callApi('delete-code.php', [
+            'ballotId'  => $ballotId,
+            'code'      => 'keepme',
+            'createdBy' => 'alice',
+        ]);
+
+        $sth = $this->db->prepare("SELECT COUNT(*) FROM random_codes WHERE code = 'keepme'");
+        $sth->execute();
+        $this->assertEquals(1, (int) $sth->fetchColumn(), 'random_codes row should be preserved');
+    }
+}

--- a/test/php/DeleteVoteTest.php
+++ b/test/php/DeleteVoteTest.php
@@ -1,0 +1,83 @@
+<?php
+
+require_once __DIR__ . '/ApiTestCase.php';
+
+/**
+ * Tests for delete-vote.php (admin single-vote deletion by ballot shortcode).
+ *
+ * Note: delete-vote.php line 37 binds :createdBy as PARAM_INT. The subquery
+ * JOINs users ON users.id = ballots.createdBy, so createdBy is a numeric user
+ * ID here — unlike other endpoints where createdBy is a username string. This
+ * means the endpoint requires a numeric user ID, not a username.
+ */
+class DeleteVoteTest extends ApiTestCase
+{
+    public function testDeletesVoteByShortcodeAndVoteId(): void
+    {
+        $userId   = $this->seedUser(['username' => 'alice']);
+        $ballotId = $this->seedBallot(['key' => 'myballot', 'createdBy' => $userId]);
+        $voteId   = $this->seedVote($ballotId, '1,2');
+
+        $result = $this->callApi('delete-vote.php', [
+            'shortcode'  => 'myballot',
+            'createdBy'  => $userId,
+            'username'   => 'alice',
+            'voteId'     => $voteId,
+        ]);
+
+        $this->assertIsArray($result['body']);
+        $this->assertTrue($result['body']['success']);
+
+        $sth = $this->db->prepare("SELECT COUNT(*) FROM votes WHERE vote_id = ?");
+        $sth->execute([$voteId]);
+        $this->assertEquals(0, (int) $sth->fetchColumn(), 'Vote should have been deleted');
+    }
+
+    public function testReturnsErrorWhenShortcodeMissing(): void
+    {
+        $userId = $this->seedUser(['username' => 'alice']);
+
+        $result = $this->callApi('delete-vote.php', [
+            'shortcode'  => '',
+            'createdBy'  => $userId,
+            'username'   => 'alice',
+            'voteId'     => 1,
+        ]);
+
+        $this->assertIsArray($result['body']);
+        $this->assertArrayHasKey('errors', $result['body']);
+        $this->assertArrayHasKey('ballotId', $result['body']['errors']);
+    }
+
+    public function testReturnsNothingWhenVoteIdMissing(): void
+    {
+        // Endpoint silently no-ops when voteId is empty (no outer if branch taken)
+        $result = $this->callApi('delete-vote.php', [
+            'shortcode'  => 'myballot',
+            'createdBy'  => '1',
+            'username'   => 'alice',
+            'voteId'     => '',
+        ]);
+
+        $this->assertEmpty($result['raw'], 'No output expected when voteId is absent');
+    }
+
+    public function testDoesNotDeleteVoteForWrongOwner(): void
+    {
+        $userId   = $this->seedUser(['username' => 'alice']);
+        $otherId  = $this->seedUser(['username' => 'bob']);
+        $ballotId = $this->seedBallot(['key' => 'owned-ballot', 'createdBy' => $userId]);
+        $voteId   = $this->seedVote($ballotId, '1,2');
+
+        $this->callApi('delete-vote.php', [
+            'shortcode'  => 'owned-ballot',
+            'createdBy'  => $otherId,
+            'username'   => 'bob',
+            'voteId'     => $voteId,
+        ]);
+
+        $sth = $this->db->prepare("SELECT COUNT(*) FROM votes WHERE vote_id = ?");
+        $sth->execute([$voteId]);
+        $this->assertEquals(1, (int) $sth->fetchColumn(), 'Vote should not be deleted by non-owner');
+    }
+}

--- a/test/php/GetGroupFieldsTest.php
+++ b/test/php/GetGroupFieldsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+require_once __DIR__ . '/ApiTestCase.php';
+
+class GetGroupFieldsTest extends ApiTestCase
+{
+    public function testReturnsFieldsWithOptions(): void
+    {
+        $ballotId = $this->seedBallot();
+        $fieldId  = $this->seedGroupField($ballotId, ['title' => 'Age Range', 'type' => 'select']);
+        $this->seedGroupOption($fieldId, 'Under 30', 0);
+        $this->seedGroupOption($fieldId, '30 and over', 1);
+
+        $result = $this->callApi('get-group-fields.php', [], ['ballotId' => $ballotId]);
+
+        $this->assertIsArray($result['body']);
+        $this->assertCount(1, $result['body']);
+        $this->assertEquals('Age Range', $result['body'][0]['title']);
+        $this->assertCount(2, $result['body'][0]['options']);
+        $this->assertEquals('Under 30',    $result['body'][0]['options'][0]['label']);
+        $this->assertEquals('30 and over', $result['body'][0]['options'][1]['label']);
+    }
+
+    public function testRequiresBallotId(): void
+    {
+        $result = $this->callApi('get-group-fields.php', [], []);
+
+        $this->assertIsArray($result['body']);
+        $this->assertArrayHasKey('errors', $result['body']);
+        $this->assertArrayHasKey('ballotId', $result['body']['errors']);
+    }
+
+    public function testReturnsEmptyArrayWhenNoFields(): void
+    {
+        $ballotId = $this->seedBallot();
+
+        $result = $this->callApi('get-group-fields.php', [], ['ballotId' => $ballotId]);
+
+        $this->assertIsArray($result['body']);
+        $this->assertEmpty($result['body']);
+    }
+
+    public function testTextFieldHasEmptyOptions(): void
+    {
+        $ballotId = $this->seedBallot();
+        $this->seedGroupField($ballotId, ['title' => 'Notes', 'type' => 'text']);
+
+        $result = $this->callApi('get-group-fields.php', [], ['ballotId' => $ballotId]);
+
+        $this->assertIsArray($result['body']);
+        $this->assertCount(1, $result['body']);
+        $this->assertEmpty($result['body'][0]['options'], 'Text fields should always return empty options array');
+    }
+
+    public function testFieldsReturnedInSortOrder(): void
+    {
+        $ballotId = $this->seedBallot();
+        $this->seedGroupField($ballotId, ['title' => 'Second', 'sort_order' => 1]);
+        $this->seedGroupField($ballotId, ['title' => 'First',  'sort_order' => 0]);
+
+        $result = $this->callApi('get-group-fields.php', [], ['ballotId' => $ballotId]);
+
+        $this->assertEquals('First',  $result['body'][0]['title']);
+        $this->assertEquals('Second', $result['body'][1]['title']);
+    }
+
+    public function testDoesNotReturnFieldsForOtherBallots(): void
+    {
+        $ballot1 = $this->seedBallot(['key' => 'ballot-one']);
+        $ballot2 = $this->seedBallot(['key' => 'ballot-two']);
+        $this->seedGroupField($ballot1, ['title' => 'Ballot1 Field']);
+
+        $result = $this->callApi('get-group-fields.php', [], ['ballotId' => $ballot2]);
+
+        $this->assertEmpty($result['body']);
+    }
+}

--- a/test/php/SaveGroupFieldsTest.php
+++ b/test/php/SaveGroupFieldsTest.php
@@ -1,0 +1,156 @@
+<?php
+
+require_once __DIR__ . '/ApiTestCase.php';
+
+class SaveGroupFieldsTest extends ApiTestCase
+{
+    public function testSavesFieldsAndOptions(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+
+        $result = $this->callApi('save-group-fields.php', [
+            'ballotId'  => $ballotId,
+            'createdBy' => 'alice',
+            'fields'    => [
+                [
+                    'title'         => 'Age Range',
+                    'question_text' => 'How old are you?',
+                    'type'          => 'select',
+                    'required'      => true,
+                    'options'       => [['label' => 'Under 30'], ['label' => '30 and over']],
+                ],
+            ],
+        ]);
+
+        $this->assertIsArray($result['body']);
+        $this->assertTrue($result['body']['data']['success']);
+
+        $sth = $this->db->prepare("SELECT * FROM voter_group_fields WHERE ballot_id = ?");
+        $sth->execute([$ballotId]);
+        $fields = $sth->fetchAll(PDO::FETCH_ASSOC);
+        $this->assertCount(1, $fields);
+        $this->assertEquals('Age Range', $fields[0]['title']);
+
+        $sth = $this->db->prepare("SELECT label FROM voter_group_options WHERE field_id = ? ORDER BY sort_order");
+        $sth->execute([$fields[0]['id']]);
+        $labels = $sth->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertEquals(['Under 30', '30 and over'], $labels);
+    }
+
+    public function testRequiresBallotId(): void
+    {
+        $result = $this->callApi('save-group-fields.php', ['createdBy' => 'alice', 'fields' => []]);
+
+        $this->assertArrayHasKey('errors', $result['body']);
+        $this->assertArrayHasKey('ballotId', $result['body']['errors']);
+    }
+
+    public function testRequiresCreatedBy(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+
+        $result = $this->callApi('save-group-fields.php', ['ballotId' => $ballotId, 'fields' => []]);
+
+        $this->assertArrayHasKey('errors', $result['body']);
+        $this->assertArrayHasKey('createdBy', $result['body']['errors']);
+    }
+
+    public function testRejectsUnauthorizedUser(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+
+        $result = $this->callApi('save-group-fields.php', [
+            'ballotId'  => $ballotId,
+            'createdBy' => 'bob',
+            'fields'    => [],
+        ]);
+
+        $this->assertArrayHasKey('errors', $result['body']);
+        $this->assertArrayHasKey('auth', $result['body']['errors']);
+    }
+
+    public function testReplacesExistingFields(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+        $fieldId  = $this->seedGroupField($ballotId, ['title' => 'Old Field']);
+        $this->seedGroupOption($fieldId, 'Old Option');
+
+        $this->callApi('save-group-fields.php', [
+            'ballotId'  => $ballotId,
+            'createdBy' => 'alice',
+            'fields'    => [
+                ['title' => 'New Field', 'question_text' => 'New?', 'type' => 'select', 'options' => []],
+            ],
+        ]);
+
+        $sth = $this->db->prepare("SELECT title FROM voter_group_fields WHERE ballot_id = ?");
+        $sth->execute([$ballotId]);
+        $titles = $sth->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertEquals(['New Field'], $titles, 'Old fields should be replaced');
+
+        $sth = $this->db->prepare("SELECT COUNT(*) FROM voter_group_options WHERE field_id = ?");
+        $sth->execute([$fieldId]);
+        $this->assertEquals(0, (int) $sth->fetchColumn(), 'Old options should be deleted');
+    }
+
+    public function testSkipsFieldsWithNoTitleAndNoQuestionText(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+
+        $this->callApi('save-group-fields.php', [
+            'ballotId'  => $ballotId,
+            'createdBy' => 'alice',
+            'fields'    => [
+                ['title' => '', 'question_text' => '', 'type' => 'select', 'options' => []],
+                ['title' => 'Real Field', 'question_text' => 'Q?', 'type' => 'select', 'options' => []],
+            ],
+        ]);
+
+        $sth = $this->db->prepare("SELECT COUNT(*) FROM voter_group_fields WHERE ballot_id = ?");
+        $sth->execute([$ballotId]);
+        $this->assertEquals(1, (int) $sth->fetchColumn());
+    }
+
+    public function testTextTypeFieldGetsNoOptions(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+
+        $this->callApi('save-group-fields.php', [
+            'ballotId'  => $ballotId,
+            'createdBy' => 'alice',
+            'fields'    => [
+                [
+                    'title'         => 'Free Text',
+                    'question_text' => 'Say something.',
+                    'type'          => 'text',
+                    'options'       => [['label' => 'Ignored']],
+                ],
+            ],
+        ]);
+
+        $sth = $this->db->prepare("SELECT id FROM voter_group_fields WHERE ballot_id = ?");
+        $sth->execute([$ballotId]);
+        $fieldId = $sth->fetchColumn();
+
+        $sth = $this->db->prepare("SELECT COUNT(*) FROM voter_group_options WHERE field_id = ?");
+        $sth->execute([$fieldId]);
+        $this->assertEquals(0, (int) $sth->fetchColumn(), 'Text fields should not have options saved');
+    }
+
+    public function testInvalidTypeDefaultsToSelect(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+
+        $this->callApi('save-group-fields.php', [
+            'ballotId'  => $ballotId,
+            'createdBy' => 'alice',
+            'fields'    => [
+                ['title' => 'Field', 'question_text' => 'Q?', 'type' => 'radio', 'options' => []],
+            ],
+        ]);
+
+        $sth = $this->db->prepare("SELECT type FROM voter_group_fields WHERE ballot_id = ?");
+        $sth->execute([$ballotId]);
+        $this->assertEquals('select', $sth->fetchColumn());
+    }
+}

--- a/test/php/TestPDO.php
+++ b/test/php/TestPDO.php
@@ -22,6 +22,14 @@ class TestPDO extends PDO
             return new NoopStatement();
         }
 
+        // Rewrite ON DUPLICATE KEY UPDATE col=col (no-op upsert) → INSERT OR IGNORE.
+        // Only fires when the no-op self-assignment form is present, so unrelated
+        // INSERT statements still surface unique/PK violations as exceptions.
+        if (preg_match('/\bON\s+DUPLICATE\s+KEY\s+UPDATE\s+(\w+)\s*=\s*\1\b/i', $query)) {
+            $query = preg_replace('/\bINSERT\b/i', 'INSERT OR IGNORE', $query, 1);
+            $query = preg_replace('/\s+ON\s+DUPLICATE\s+KEY\s+UPDATE\s+\w+\s*=\s*\w+/i', '', $query);
+        }
+
         // Rewrite DATE_SUB(NOW()|UTC_TIMESTAMP(), INTERVAL ...) → datetime('now', '-...')
         $query = preg_replace_callback(
             '/DATE_SUB\s*\(\s*(?:NOW|UTC_TIMESTAMP)\(\)\s*,\s*INTERVAL\s+(\d+)\s+(\w+)\s*\)/i',

--- a/test/php/TransferBallotTest.php
+++ b/test/php/TransferBallotTest.php
@@ -1,0 +1,102 @@
+<?php
+
+require_once __DIR__ . '/ApiTestCase.php';
+
+class TransferBallotTest extends ApiTestCase
+{
+    public function testTransfersToBallotToExistingUser(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+        $this->seedUser(['username' => 'bob']);
+
+        $result = $this->callApi('transfer-ballot.php', [
+            'ballotId'        => $ballotId,
+            'currentOwnerId'  => 'alice',
+            'newOwnerUsername' => 'bob',
+        ]);
+
+        $this->assertIsArray($result['body']);
+        $this->assertTrue($result['body']['data']['success']);
+        $this->assertStringContainsString('bob', $result['body']['data']['message']);
+
+        $sth = $this->db->prepare("SELECT createdBy FROM ballots WHERE id = ?");
+        $sth->execute([$ballotId]);
+        $newOwner = $sth->fetchColumn();
+        $this->assertNotEquals('alice', $newOwner, 'Ownership should have changed');
+    }
+
+    public function testTransfersToGuestWhenUsernameNotFound(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+
+        $result = $this->callApi('transfer-ballot.php', [
+            'ballotId'         => $ballotId,
+            'currentOwnerId'   => 'alice',
+            'newOwnerUsername' => 'nobody',
+        ]);
+
+        $this->assertIsArray($result['body']);
+        $this->assertTrue($result['body']['data']['success']);
+        $this->assertStringContainsString('guest', $result['body']['data']['message']);
+
+        $sth = $this->db->prepare("SELECT createdBy FROM ballots WHERE id = ?");
+        $sth->execute([$ballotId]);
+        $this->assertEquals('guest', $sth->fetchColumn());
+    }
+
+    public function testRequiresBallotId(): void
+    {
+        $result = $this->callApi('transfer-ballot.php', [
+            'currentOwnerId'   => 'alice',
+            'newOwnerUsername' => 'bob',
+        ]);
+
+        $this->assertArrayHasKey('errors', $result['body']);
+        $this->assertArrayHasKey('ballotId', $result['body']['errors']);
+    }
+
+    public function testRequiresCurrentOwnerId(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+
+        $result = $this->callApi('transfer-ballot.php', [
+            'ballotId'         => $ballotId,
+            'newOwnerUsername' => 'bob',
+        ]);
+
+        $this->assertArrayHasKey('errors', $result['body']);
+        $this->assertArrayHasKey('currentOwnerId', $result['body']['errors']);
+    }
+
+    public function testRequiresNewOwnerUsername(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+
+        $result = $this->callApi('transfer-ballot.php', [
+            'ballotId'        => $ballotId,
+            'currentOwnerId'  => 'alice',
+            'newOwnerUsername' => '',
+        ]);
+
+        $this->assertArrayHasKey('errors', $result['body']);
+        $this->assertArrayHasKey('newOwnerUsername', $result['body']['errors']);
+    }
+
+    public function testDoesNotTransferWhenNotCurrentOwner(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+
+        $result = $this->callApi('transfer-ballot.php', [
+            'ballotId'         => $ballotId,
+            'currentOwnerId'   => 'bob',
+            'newOwnerUsername' => 'carol',
+        ]);
+
+        $this->assertArrayHasKey('errors', $result['body']);
+        $this->assertArrayHasKey('ballot', $result['body']['errors']);
+
+        $sth = $this->db->prepare("SELECT createdBy FROM ballots WHERE id = ?");
+        $sth->execute([$ballotId]);
+        $this->assertEquals('alice', $sth->fetchColumn(), 'Ownership should be unchanged');
+    }
+}

--- a/test/php/UpdateCodeLabelTest.php
+++ b/test/php/UpdateCodeLabelTest.php
@@ -1,0 +1,78 @@
+<?php
+
+require_once __DIR__ . '/ApiTestCase.php';
+
+class UpdateCodeLabelTest extends ApiTestCase
+{
+    public function testUpdatesLabel(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+        $this->seedVoterCode($ballotId, 'abc123');
+
+        $result = $this->callApi('update-code-label.php', [
+            'ballotId'  => $ballotId,
+            'code'      => 'abc123',
+            'createdBy' => 'alice',
+            'label'     => 'Seat 1',
+        ]);
+
+        $this->assertIsArray($result['body']);
+        $this->assertTrue($result['body']['success']);
+
+        $sth = $this->db->prepare("
+            SELECT bc.label FROM ballot_codes bc
+            JOIN random_codes rc ON rc.id = bc.random_code_id
+            WHERE bc.ballot_id = ? AND rc.code = ?
+        ");
+        $sth->execute([$ballotId, 'abc123']);
+        $this->assertEquals('Seat 1', $sth->fetchColumn());
+    }
+
+    public function testAllowsEmptyLabel(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+        $this->seedVoterCode($ballotId, 'abc123');
+
+        // First set a label
+        $this->callApi('update-code-label.php', [
+            'ballotId'  => $ballotId,
+            'code'      => 'abc123',
+            'createdBy' => 'alice',
+            'label'     => 'Seat 1',
+        ]);
+
+        // Then clear it
+        $result = $this->callApi('update-code-label.php', [
+            'ballotId'  => $ballotId,
+            'code'      => 'abc123',
+            'createdBy' => 'alice',
+            'label'     => '',
+        ]);
+
+        $this->assertTrue($result['body']['success']);
+    }
+
+    public function testRequiresMissingFields(): void
+    {
+        $result = $this->callApi('update-code-label.php', ['label' => 'Test']);
+
+        $this->assertArrayHasKey('errors', $result['body']);
+        $this->assertArrayHasKey('params', $result['body']['errors']);
+    }
+
+    public function testRejectsUnauthorizedUser(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+        $this->seedVoterCode($ballotId, 'mycode');
+
+        $result = $this->callApi('update-code-label.php', [
+            'ballotId'  => $ballotId,
+            'code'      => 'mycode',
+            'createdBy' => 'bob',
+            'label'     => 'Seat 1',
+        ]);
+
+        $this->assertArrayHasKey('errors', $result['body']);
+        $this->assertArrayHasKey('auth', $result['body']['errors']);
+    }
+}


### PR DESCRIPTION
New test files (40 new tests):
- test/php/SaveGroupFieldsTest.php (7 tests) — full replace, type validation, ownership
- test/php/GetGroupFieldsTest.php (6 tests) — options, text type, sort order, isolation
- test/php/TransferBallotTest.php (6 tests) — existing user, guest fallback, ownership
- test/php/DeleteCodeTest.php (7 tests) — unused code, vote guard, random_codes preserved
- test/php/UpdateCodeLabelTest.php (4 tests) — label update, empty label, auth
- test/php/DeleteVoteTest.php (4 tests) — shortcode+voteId deletion, non-owner guard
- test/php/AddUserTest.php (5 tests) — id generation, field filtering, duplicate handling

SQL portability fixes (semantically identical, MySQL + SQLite compatible):
- src/api/delete-code.php: MySQL JOIN DELETE → subquery DELETE
- src/api/update-code-label.php: MySQL JOIN UPDATE → subquery UPDATE

TestPDO improvements:
- Add ON DUPLICATE KEY UPDATE id=id → INSERT OR IGNORE rewrite for SQLite