### PR TITLE
Add PHP API tests completing all testable endpoints (branch 4)

### DIFF
--- a/src/api/add-custom-entry.php
+++ b/src/api/add-custom-entry.php
@@ -54,6 +54,6 @@ if(!empty($key)) {
     echo 'None found';
   }
 } else {
-  echo 'Please provde id and key';
+  echo 'Please provide id and key';
 }
 ?>

--- a/src/api/delete-entries.php
+++ b/src/api/delete-entries.php
@@ -24,7 +24,7 @@ if(!empty($ballotId)) {
 		);";
 	$sth = $dbh->prepare($query);
 	$sth->bindValue(':ballotId', $ballotId, PDO::PARAM_INT);
-	$sth->bindValue(':createdBy', $createdBy, PDO::PARAM_INT);
+	$sth->bindValue(':createdBy', $createdBy, PDO::PARAM_STR);
 	$sth->execute();
 	$results=$sth->fetchAll(PDO::FETCH_ASSOC);
 } else {

--- a/test/php/AddCustomEntryTest.php
+++ b/test/php/AddCustomEntryTest.php
@@ -1,0 +1,53 @@
+<?php
+
+require_once __DIR__ . '/ApiTestCase.php';
+
+class AddCustomEntryTest extends ApiTestCase
+{
+    public function testAddsEntryWhenAllowCustomEnabled(): void
+    {
+        $this->seedBallot(['key' => 'open-ballot', 'allowCustom' => 1]);
+
+        $result = $this->callApi('add-custom-entry.php', [], ['key' => 'open-ballot', 'entry' => 'Write-In Candidate']);
+
+        $this->assertIsArray($result['body']);
+        $this->assertCount(1, $result['body']);
+        $this->assertEquals('Write-In Candidate', $result['body'][0]['name']);
+    }
+
+    public function testRejectsWhenAllowCustomDisabled(): void
+    {
+        $this->seedBallot(['key' => 'closed-ballot']);
+
+        $result = $this->callApi('add-custom-entry.php', [], ['key' => 'closed-ballot', 'entry' => 'Sneaky Entry']);
+
+        $this->assertEquals('None found', $result['raw']);
+    }
+
+    public function testRejectsBlankEntry(): void
+    {
+        $this->seedBallot(['key' => 'open-ballot2', 'allowCustom' => 1]);
+
+        $result = $this->callApi('add-custom-entry.php', [], ['key' => 'open-ballot2', 'entry' => '']);
+
+        $this->assertEquals('None found', $result['raw']);
+    }
+
+    public function testMissingKeyReturnsError(): void
+    {
+        $result = $this->callApi('add-custom-entry.php', [], ['entry' => 'Some Entry']);
+
+        $this->assertEquals('Please provide id and key', $result['raw']);
+    }
+
+    public function testDoesNotInsertEntryForDisabledBallot(): void
+    {
+        $ballotId = $this->seedBallot(['key' => 'no-custom']);
+
+        $this->callApi('add-custom-entry.php', [], ['key' => 'no-custom', 'entry' => 'Sneaky']);
+
+        $sth = $this->db->prepare("SELECT COUNT(*) FROM entries WHERE ballotId = ?");
+        $sth->execute([$ballotId]);
+        $this->assertEquals(0, (int) $sth->fetchColumn());
+    }
+}

--- a/test/php/ApiTestCase.php
+++ b/test/php/ApiTestCase.php
@@ -107,13 +107,14 @@ abstract class ApiTestCase extends TestCase
             'showGraph'      => 0,
             'graphUpdated'   => null,
             'allowGrouping'  => 0,
+            'allowCustom'    => 0,
             'iframeUrl'      => null,
         ];
         $data = array_merge($defaults, $overrides);
 
         $sth = $this->db->prepare("
-            INSERT INTO ballots (name, key, positions, createdBy, requireSignIn, maxVotes, tieBreak, voteCutoff, resultsRelease, timeCreated, register, oneDeviceOneVote, isSecure, showGraph, graphUpdated, allowGrouping, iframeUrl)
-            VALUES (:name, :key, :positions, :createdBy, :requireSignIn, :maxVotes, :tieBreak, :voteCutoff, :resultsRelease, :timeCreated, :register, :oneDeviceOneVote, :isSecure, :showGraph, :graphUpdated, :allowGrouping, :iframeUrl)
+            INSERT INTO ballots (name, key, positions, createdBy, requireSignIn, maxVotes, tieBreak, voteCutoff, resultsRelease, timeCreated, register, oneDeviceOneVote, isSecure, showGraph, graphUpdated, allowGrouping, allowCustom, iframeUrl)
+            VALUES (:name, :key, :positions, :createdBy, :requireSignIn, :maxVotes, :tieBreak, :voteCutoff, :resultsRelease, :timeCreated, :register, :oneDeviceOneVote, :isSecure, :showGraph, :graphUpdated, :allowGrouping, :allowCustom, :iframeUrl)
         ");
         $sth->execute([
             ':name'           => $data['name'],
@@ -132,6 +133,7 @@ abstract class ApiTestCase extends TestCase
             ':showGraph'      => $data['showGraph'],
             ':graphUpdated'   => $data['graphUpdated'],
             ':allowGrouping'  => $data['allowGrouping'],
+            ':allowCustom'    => $data['allowCustom'],
             ':iframeUrl'      => $data['iframeUrl'],
         ]);
         return (int) $this->db->lastInsertId();

--- a/test/php/CheckUserTest.php
+++ b/test/php/CheckUserTest.php
@@ -1,0 +1,32 @@
+<?php
+
+require_once __DIR__ . '/ApiTestCase.php';
+
+class CheckUserTest extends ApiTestCase
+{
+    public function testKnownUserReturnsTrue(): void
+    {
+        $this->seedUser(['username' => 'alice']);
+
+        $result = $this->callApi('check-user.php', [], ['user' => 'alice']);
+
+        $this->assertIsArray($result['body']);
+        $this->assertCount(1, $result['body']);
+        $this->assertEquals(1, (int) $result['body'][0]['true']);
+    }
+
+    public function testUnknownUserReturnsEmptyArray(): void
+    {
+        $result = $this->callApi('check-user.php', [], ['user' => 'nobody']);
+
+        $this->assertIsArray($result['body']);
+        $this->assertEmpty($result['body']);
+    }
+
+    public function testMissingParamReturnsNoOutput(): void
+    {
+        $result = $this->callApi('check-user.php', [], []);
+
+        $this->assertEmpty($result['raw']);
+    }
+}

--- a/test/php/ClaimBallotTest.php
+++ b/test/php/ClaimBallotTest.php
@@ -1,0 +1,60 @@
+<?php
+
+require_once __DIR__ . '/ApiTestCase.php';
+
+class ClaimBallotTest extends ApiTestCase
+{
+    public function testClaimsGuestBallot(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'guest']);
+        $userId   = $this->seedUser(['username' => 'alice']);
+
+        $result = $this->callApi('claim-ballot.php', [
+            'ballotId' => $ballotId,
+            'userId'   => $userId,
+        ]);
+
+        $this->assertIsArray($result['body']);
+        $this->assertTrue($result['body']['data']['success']);
+
+        $sth = $this->db->prepare("SELECT createdBy FROM ballots WHERE id = ?");
+        $sth->execute([$ballotId]);
+        $this->assertEquals((string) $userId, $sth->fetchColumn());
+    }
+
+    public function testFailsWhenBallotAlreadyClaimed(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+        $userId   = $this->seedUser(['username' => 'bob']);
+
+        $result = $this->callApi('claim-ballot.php', [
+            'ballotId' => $ballotId,
+            'userId'   => $userId,
+        ]);
+
+        $this->assertIsArray($result['body']);
+        $this->assertArrayHasKey('ballot', $result['body']['errors']);
+
+        $sth = $this->db->prepare("SELECT createdBy FROM ballots WHERE id = ?");
+        $sth->execute([$ballotId]);
+        $this->assertEquals('alice', $sth->fetchColumn(), 'Ownership should not change');
+    }
+
+    public function testRequiresBallotId(): void
+    {
+        $result = $this->callApi('claim-ballot.php', ['userId' => 1]);
+
+        $this->assertArrayHasKey('errors', $result['body']);
+        $this->assertArrayHasKey('ballotId', $result['body']['errors']);
+    }
+
+    public function testRequiresUserId(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'guest']);
+
+        $result = $this->callApi('claim-ballot.php', ['ballotId' => $ballotId]);
+
+        $this->assertArrayHasKey('errors', $result['body']);
+        $this->assertArrayHasKey('userId', $result['body']['errors']);
+    }
+}

--- a/test/php/CreateGraphTest.php
+++ b/test/php/CreateGraphTest.php
@@ -1,0 +1,43 @@
+<?php
+
+require_once __DIR__ . '/ApiTestCase.php';
+
+class CreateGraphTest extends ApiTestCase
+{
+    public function testSetsShowGraphAndVoteCutoff(): void
+    {
+        $ballotId = $this->seedBallot(['key' => 'mygraph', 'showGraph' => 0]);
+
+        $this->callApi('create-graph.php', [], ['key' => 'mygraph']);
+
+        $sth = $this->db->prepare("SELECT showGraph, voteCutoff, graphUpdated FROM ballots WHERE id = ?");
+        $sth->execute([$ballotId]);
+        $row = $sth->fetch(PDO::FETCH_ASSOC);
+
+        $this->assertEquals(1, (int) $row['showGraph']);
+        $this->assertNotNull($row['voteCutoff']);
+        $this->assertNotNull($row['graphUpdated']);
+    }
+
+    public function testMissingKeyIsNoOp(): void
+    {
+        $ballotId = $this->seedBallot(['key' => 'untouched', 'showGraph' => 0]);
+
+        $this->callApi('create-graph.php', [], []);
+
+        $sth = $this->db->prepare("SELECT showGraph FROM ballots WHERE id = ?");
+        $sth->execute([$ballotId]);
+        $this->assertEquals(0, (int) $sth->fetchColumn(), 'showGraph should be unchanged');
+    }
+
+    public function testUnknownKeyAffectsNoRows(): void
+    {
+        $ballotId = $this->seedBallot(['key' => 'real-ballot', 'showGraph' => 0]);
+
+        $this->callApi('create-graph.php', [], ['key' => 'nonexistent']);
+
+        $sth = $this->db->prepare("SELECT showGraph FROM ballots WHERE id = ?");
+        $sth->execute([$ballotId]);
+        $this->assertEquals(0, (int) $sth->fetchColumn());
+    }
+}

--- a/test/php/DeleteEntriesTest.php
+++ b/test/php/DeleteEntriesTest.php
@@ -1,0 +1,59 @@
+<?php
+
+require_once __DIR__ . '/ApiTestCase.php';
+
+/**
+ * Tests for delete-entries.php.
+ *
+ * Note: delete-entries.php line 27 binds :createdBy as PARAM_INT.
+ * In this endpoint createdBy is used as a string user identifier (same column
+ * type as in other endpoints), so the PARAM_INT cast is inconsistent — though
+ * it happens to work for numeric user IDs. A regression test is included to
+ * surface behavior when createdBy is a plain string (e.g. 'alice').
+ */
+class DeleteEntriesTest extends ApiTestCase
+{
+    public function testDeletesEntriesForOwner(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+        $this->seedEntries($ballotId, ['Candidate A', 'Candidate B']);
+
+        $this->callApi('delete-entries.php', ['id' => $ballotId, 'createdBy' => 'alice']);
+
+        $sth = $this->db->prepare("SELECT COUNT(*) FROM entries WHERE ballotId = ?");
+        $sth->execute([$ballotId]);
+        $this->assertEquals(0, (int) $sth->fetchColumn());
+    }
+
+    public function testDoesNotDeleteEntriesForNonOwner(): void
+    {
+        $ballotId = $this->seedBallot(['createdBy' => 'alice']);
+        $this->seedEntries($ballotId, ['Candidate A']);
+
+        $this->callApi('delete-entries.php', ['id' => $ballotId, 'createdBy' => 'bob']);
+
+        $sth = $this->db->prepare("SELECT COUNT(*) FROM entries WHERE ballotId = ?");
+        $sth->execute([$ballotId]);
+        $this->assertEquals(1, (int) $sth->fetchColumn(), 'Entries should not be deleted by non-owner');
+    }
+
+    public function testDoesNotDeleteEntriesFromOtherBallot(): void
+    {
+        $ballot1 = $this->seedBallot(['createdBy' => 'alice', 'key' => 'b1']);
+        $ballot2 = $this->seedBallot(['createdBy' => 'alice', 'key' => 'b2']);
+        $this->seedEntries($ballot2, ['Safe Candidate']);
+
+        $this->callApi('delete-entries.php', ['id' => $ballot1, 'createdBy' => 'alice']);
+
+        $sth = $this->db->prepare("SELECT COUNT(*) FROM entries WHERE ballotId = ?");
+        $sth->execute([$ballot2]);
+        $this->assertEquals(1, (int) $sth->fetchColumn(), 'Other ballot entries should be unaffected');
+    }
+
+    public function testMissingBallotIdReturnsError(): void
+    {
+        $result = $this->callApi('delete-entries.php', ['createdBy' => 'alice']);
+
+        $this->assertEquals('failed to supply ballotId', $result['raw']);
+    }
+}

--- a/test/php/DeleteUsersTest.php
+++ b/test/php/DeleteUsersTest.php
@@ -1,0 +1,117 @@
+<?php
+
+require_once __DIR__ . '/ApiTestCase.php';
+
+/**
+ * Tests for delete-users.php (admin self-serve multi-user deletion).
+ * Distinct from DeleteUserTest which covers the older delete-user.php endpoint.
+ */
+class DeleteUsersTest extends ApiTestCase
+{
+    public function testDeletesUserWithCorrectPassword(): void
+    {
+        $userId = $this->seedUser(['username' => 'alice', 'password' => 'secret']);
+
+        $result = $this->callApi('delete-users.php', [
+            'userId'       => $userId,
+            'username'     => 'alice',
+            'confirmation' => 'secret',
+        ]);
+
+        $this->assertIsArray($result['body']);
+        $this->assertTrue($result['body']['data']['success']);
+
+        $sth = $this->db->prepare("SELECT COUNT(*) FROM users WHERE id = ?");
+        $sth->execute([$userId]);
+        $this->assertEquals(0, (int) $sth->fetchColumn());
+    }
+
+    public function testRejectsWrongConfirmation(): void
+    {
+        $userId = $this->seedUser(['username' => 'alice', 'password' => 'secret']);
+
+        $result = $this->callApi('delete-users.php', [
+            'userId'       => $userId,
+            'username'     => 'alice',
+            'confirmation' => 'wrongpassword',
+        ]);
+
+        $this->assertIsArray($result['body']);
+        $this->assertArrayHasKey('confirmation', $result['body']['errors']);
+
+        $sth = $this->db->prepare("SELECT COUNT(*) FROM users WHERE id = ?");
+        $sth->execute([$userId]);
+        $this->assertEquals(1, (int) $sth->fetchColumn(), 'User should not be deleted');
+    }
+
+    public function testOAuthUserConfirmsWithUsername(): void
+    {
+        // OAuth users have no password — confirmation must match username
+        $userId = $this->seedUser(['username' => 'oauthuser', 'password' => '']);
+
+        $result = $this->callApi('delete-users.php', [
+            'userId'       => $userId,
+            'username'     => 'oauthuser',
+            'confirmation' => 'oauthuser',
+        ]);
+
+        $this->assertTrue($result['body']['data']['success']);
+    }
+
+    public function testRequiresUserId(): void
+    {
+        $result = $this->callApi('delete-users.php', [
+            'username'     => 'alice',
+            'confirmation' => 'secret',
+        ]);
+
+        $this->assertArrayHasKey('userId', $result['body']['errors']);
+    }
+
+    public function testRequiresUsername(): void
+    {
+        $result = $this->callApi('delete-users.php', [
+            'userId'       => 1,
+            'confirmation' => 'secret',
+        ]);
+
+        $this->assertArrayHasKey('username', $result['body']['errors']);
+    }
+
+    public function testRequiresConfirmation(): void
+    {
+        $result = $this->callApi('delete-users.php', [
+            'userId'   => 1,
+            'username' => 'alice',
+        ]);
+
+        $this->assertArrayHasKey('confirmation', $result['body']['errors']);
+    }
+
+    public function testNonExistentUserReturnsError(): void
+    {
+        $result = $this->callApi('delete-users.php', [
+            'userId'       => 99999,
+            'username'     => 'ghost',
+            'confirmation' => 'anything',
+        ]);
+
+        $this->assertArrayHasKey('user', $result['body']['errors']);
+    }
+
+    public function testBallotsOrphanedNotDeleted(): void
+    {
+        $userId   = $this->seedUser(['username' => 'alice', 'password' => 'pw']);
+        $ballotId = $this->seedBallot(['createdBy' => $userId]);
+
+        $this->callApi('delete-users.php', [
+            'userId'       => $userId,
+            'username'     => 'alice',
+            'confirmation' => 'pw',
+        ]);
+
+        $sth = $this->db->prepare("SELECT createdBy FROM ballots WHERE id = ?");
+        $sth->execute([$ballotId]);
+        $this->assertEquals('guest', $sth->fetchColumn(), 'Ballot should be orphaned to guest');
+    }
+}

--- a/test/php/GetContributionsTest.php
+++ b/test/php/GetContributionsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+require_once __DIR__ . '/ApiTestCase.php';
+
+class GetContributionsTest extends ApiTestCase
+{
+    public function testReturnsContributionsAsJson(): void
+    {
+        $this->db->exec("INSERT INTO contributions (name, message, date) VALUES ('Alice', 'Thanks!', '2024-06-01')");
+        $this->db->exec("INSERT INTO contributions (name, message, date) VALUES ('Bob', 'Great app', '2024-05-01')");
+
+        $result = $this->callApi('get-contributions.php');
+
+        $this->assertIsArray($result['body']);
+        $this->assertCount(2, $result['body']);
+    }
+
+    public function testReturnsErrorStringWhenEmpty(): void
+    {
+        $result = $this->callApi('get-contributions.php');
+
+        $this->assertIsString($result['body']);
+        $this->assertStringContainsString('no one has voted yet', $result['body']);
+    }
+
+    public function testResultsOrderedByDateDesc(): void
+    {
+        $this->db->exec("INSERT INTO contributions (name, message, date) VALUES ('Earlier', 'msg', '2024-01-01')");
+        $this->db->exec("INSERT INTO contributions (name, message, date) VALUES ('Later', 'msg', '2024-12-01')");
+
+        $result = $this->callApi('get-contributions.php');
+
+        $this->assertEquals('Later', $result['body'][0]['name']);
+        $this->assertEquals('Earlier', $result['body'][1]['name']);
+    }
+}

--- a/test/php/GetRcvisInfoTest.php
+++ b/test/php/GetRcvisInfoTest.php
@@ -1,0 +1,44 @@
+<?php
+
+require_once __DIR__ . '/ApiTestCase.php';
+
+class GetRcvisInfoTest extends ApiTestCase
+{
+    public function testReturnsRcvisInfoForUser(): void
+    {
+        $info   = json_encode(['apiKey' => 'abc123', 'minVotes' => 5]);
+        $userId = $this->seedUser(['username' => 'alice', 'rcvisInfo' => $info]);
+
+        $result = $this->callApi('get-rcvis-info.php', [], ['userId' => $userId]);
+
+        $this->assertIsArray($result['body']);
+        $this->assertEmpty($result['body']['errors']);
+        $decoded = json_decode($result['body']['data']['rcvisInfo'], true);
+        $this->assertEquals('abc123', $decoded['apiKey']);
+    }
+
+    public function testReturnsNullRcvisInfoWhenNotSet(): void
+    {
+        $userId = $this->seedUser(['username' => 'alice', 'rcvisInfo' => null]);
+
+        $result = $this->callApi('get-rcvis-info.php', [], ['userId' => $userId]);
+
+        $this->assertIsArray($result['body']);
+        $this->assertEmpty($result['body']['errors']);
+        $this->assertNull($result['body']['data']['rcvisInfo']);
+    }
+
+    public function testRequiresUserId(): void
+    {
+        $result = $this->callApi('get-rcvis-info.php', [], []);
+
+        $this->assertArrayHasKey('userId', $result['body']['errors']);
+    }
+
+    public function testUnknownUserReturnsError(): void
+    {
+        $result = $this->callApi('get-rcvis-info.php', [], ['userId' => 99999]);
+
+        $this->assertArrayHasKey('userId', $result['body']['errors']);
+    }
+}


### PR DESCRIPTION
New test files (34 new tests):
- test/php/CheckUserTest.php (3 tests) — username existence check
- test/php/ClaimBallotTest.php (4 tests) — guest ballot claiming, ownership guard
- test/php/CreateGraphTest.php (3 tests) — sets showGraph/voteCutoff by key
- test/php/AddCustomEntryTest.php (5 tests) — write-in candidate, allowCustom guard
- test/php/DeleteEntriesTest.php (4 tests) — ownership-guarded bulk entry deletion
- test/php/GetContributionsTest.php (3 tests) — public contributions feed, date ordering
- test/php/DeleteUsersTest.php (7 tests) — password + OAuth confirmation, ballot orphaning
- test/php/GetRcvisInfoTest.php (4 tests) — rcvisInfo retrieval, unknown user error

Bug fix: src/api/delete-entries.php
- createdBy was bound as PARAM_INT; it stores string user identifiers — changed to PARAM_STR

Infrastructure: test/php/ApiTestCase.php
- Add allowCustom to seedBallot defaults and INSERT