### PR TITLE
Add GitHub Actions workflow to run Vitest + PHPUnit on push/PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,5 +31,12 @@ jobs:
       - name: Install PHP dependencies
         run: composer install --no-progress --prefer-dist --no-interaction
 
+      - name: Provide PHP config stub
+        # src/api/config.php is gitignored. Endpoints `require_once("config.php")`,
+        # so without this they fatal before PHPUnit can read their output.
+        # config_sample.php short-circuits when PHPUNIT_RUNNING is defined, so
+        # the SQLite $dbh from prepend.php remains in scope.
+        run: cp src/api/config_sample.php src/api/config.php
+
       - name: Run tests (Vitest + PHPUnit)
         run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: pdo_sqlite
+          coverage: none
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      - name: Install PHP dependencies
+        run: composer install --no-progress --prefer-dist --no-interaction
+
+      - name: Run tests (Vitest + PHPUnit)
+        run: npm test


### PR DESCRIPTION
## What
Adds a GitHub Actions workflow at .github/workflows/test.yml that runs the existing test suite on every push and pull request.

## Why
There's currently no CI. Tests only run when a contributor remembers to run them locally, which means regressions can land on `master` unnoticed.

## How it works
The workflow:
- Checks out the repo
- Installs Node (version from .nvmrc) and PHP 8.2 with the `pdo_sqlite` extension
- Runs `npm ci` and `composer install` for reproducible installs
- Copies src/api/config_sample.php → src/api/config.php (the sample already short-circuits under `PHPUNIT_RUNNING`, so this is a no-op stub for tests; the real config.php stays gitignored)
- Runs `npm test`, which chains `vitest run` and `./vendor/bin/phpunit`

Total runtime: ~1 minute.

## Verification
Passing on this branch: see the green check on the latest commit.

## Notes for the maintainer
- **No secrets required.** The PHP test harness uses SQLite, so no DB credentials are needed.
- **Not enforced on merges.** This PR only adds the workflow file. To require the check before merging, go to Settings → Branches → branch protection rules → require the `test` status check. Entirely your call.
- **To disable later:** delete the file, or toggle Settings → Actions → "Disable actions".
- GitHub Actions is free for public repos.