### PR TITLE
Extract RCVis display helpers into dedicated module

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -12,6 +12,12 @@ import mc from './utils/mc.js';
 import VoteFactory, { initScope } from './factories/vote-factory.js';
 import { initAuth } from './auth.js';
 import { initBallot, assignFieldSlugs, displayTitle } from './ballot.js';
+import {
+  shouldPatchGraph,
+  shouldAutoUpdate,
+  canSeeGraph as rcvisCanSeeGraph,
+  shouldUsePostCutoffPath
+} from './utils/rcvis-helpers.js';
 
 /* Iframe auto-resize: hosted pages can postMessage their height */
 window.addEventListener('message', function (e) {
@@ -442,10 +448,14 @@ mainApp.controller('MainCtrl', [
           $s.graphStatus = status;
           var minVotes = ($s.user.rcvisInfo && $s.user.rcvisInfo.minVotes) || 15;
           var minMinutes = ($s.user.rcvisInfo && $s.user.rcvisInfo.minMinutes) || 120;
-          var votesThresholdMet = status.votesSinceUpdate >= minVotes;
-          var timeThresholdMet = status.minutesSinceUpdate !== null && status.minutesSinceUpdate >= minMinutes;
 
-          if ($s.rcvisSlug && votesThresholdMet && timeThresholdMet) {
+          if (shouldAutoUpdate({
+            rcvisSlug: $s.rcvisSlug,
+            votesSinceUpdate: status.votesSinceUpdate,
+            minutesSinceUpdate: status.minutesSinceUpdate,
+            minVotes: minVotes,
+            minMinutes: minMinutes
+          })) {
             $s.graphUpdating = true;
             $s.patchRcvis = true;
             $s.getResults();
@@ -682,15 +692,24 @@ mainApp.controller('MainCtrl', [
           var evaluateGraph = function () {
             var isCreator = $s.user.id == createdBy;
             var creatorWithKey = isCreator && $s.user.rcvisInfo && $s.user.rcvisInfo.apiKey;
-            var canSeeGraph = resultsVisible || creatorWithKey;
+            var canSee = rcvisCanSeeGraph({
+              resultsDate: resultsDate,
+              now: now,
+              isCreator: isCreator,
+              rcvisInfo: $s.user.rcvisInfo
+            });
 
-            if (canSeeGraph) {
+            if (canSee) {
               $s.ballotName = ballot.ballotName;
               $s.ballotId = ballot.id;
 
-              if (voteCutoffDate && voteCutoffDate < now) {
+              if (shouldUsePostCutoffPath({ voteCutoffDate: voteCutoffDate, now: now })) {
                 // Vote cutoff has passed: one final update if stale
-                $s.patchRcvis = !$s.rcvisSlug || !$s.graphUpdated || $s.graphUpdated < mostRecentVote;
+                $s.patchRcvis = shouldPatchGraph({
+                  rcvisSlug: $s.rcvisSlug,
+                  graphUpdated: $s.graphUpdated,
+                  mostRecentVote: mostRecentVote
+                });
                 if (!$s.patchRcvis) {
                   $s.displayRcvisIframe();
                 }
@@ -708,7 +727,6 @@ mainApp.controller('MainCtrl', [
             }
           };
 
-          var resultsVisible = !resultsDate || resultsDate < now;
           evaluateGraph();
 
           // If rcvisInfo is not yet loaded (cookie-restored session), re-evaluate once it arrives

--- a/src/js/utils/rcvis-helpers.js
+++ b/src/js/utils/rcvis-helpers.js
@@ -1,0 +1,51 @@
+/**
+ * Pure helpers for RCVis graph display decisions.
+ *
+ * Extracted from main.js so they can be unit-tested without booting AngularJS.
+ * Keep these dependency-free — no moment, no scope, no DOM.
+ */
+
+/**
+ * True if the rcvis graph is stale relative to the most recent vote
+ * (used on the post-cutoff path).
+ */
+export function shouldPatchGraph({ rcvisSlug, graphUpdated, mostRecentVote }) {
+  return !rcvisSlug || !graphUpdated || graphUpdated < mostRecentVote;
+}
+
+/**
+ * True if both the vote-count and time thresholds indicate it's time to
+ * auto-update the graph. `minVotes` / `minMinutes` fall back to 15 / 120
+ * when falsy, matching the production defaults in main.js.
+ */
+export function shouldAutoUpdate({
+  rcvisSlug,
+  votesSinceUpdate,
+  minutesSinceUpdate,
+  minVotes,
+  minMinutes
+}) {
+  var resolvedMinVotes = minVotes || 15;
+  var resolvedMinMinutes = minMinutes || 120;
+  var votesThresholdMet = votesSinceUpdate >= resolvedMinVotes;
+  var timeThresholdMet =
+    minutesSinceUpdate !== null && minutesSinceUpdate >= resolvedMinMinutes;
+  return !!rcvisSlug && votesThresholdMet && timeThresholdMet;
+}
+
+/**
+ * True if the current viewer is allowed to see the live graph.
+ * `isCreator` should reflect `$s.user.id == ballot.createdBy`.
+ */
+export function canSeeGraph({ resultsDate, now, isCreator, rcvisInfo }) {
+  var resultsVisible = !resultsDate || resultsDate < now;
+  var creatorWithKey = isCreator && rcvisInfo && rcvisInfo.apiKey;
+  return resultsVisible || !!creatorWithKey;
+}
+
+/**
+ * True if the ballot's voting window has closed (cutoff exists and is past).
+ */
+export function shouldUsePostCutoffPath({ voteCutoffDate, now }) {
+  return !!(voteCutoffDate && voteCutoffDate < now);
+}

--- a/test/rcvis-logic.test.js
+++ b/test/rcvis-logic.test.js
@@ -1,35 +1,15 @@
 import { describe, it, expect } from 'vitest';
+import {
+  shouldPatchGraph,
+  shouldAutoUpdate,
+  canSeeGraph,
+  shouldUsePostCutoffPath
+} from '@src/js/utils/rcvis-helpers.js';
 
 /**
  * Pure-logic tests for RCVis graph display decisions.
- * These test the threshold/staleness logic without needing the full AngularJS scope.
+ * Imports the real implementations from src/js/utils/rcvis-helpers.js.
  */
-
-// Replicate the staleness logic from main.js (post-cutoff path)
-function shouldPatchGraph({ rcvisSlug, graphUpdated, mostRecentVote }) {
-  return !rcvisSlug || !graphUpdated || graphUpdated < mostRecentVote;
-}
-
-// Replicate the auto-update threshold logic from main.js checkGraphStatus
-function shouldAutoUpdate({ rcvisSlug, votesSinceUpdate, minutesSinceUpdate, minVotes, minMinutes }) {
-  minVotes = minVotes || 15;
-  minMinutes = minMinutes || 120;
-  var votesThresholdMet = votesSinceUpdate >= minVotes;
-  var timeThresholdMet = minutesSinceUpdate !== null && minutesSinceUpdate >= minMinutes;
-  return !!rcvisSlug && votesThresholdMet && timeThresholdMet;
-}
-
-// Replicate the graph visibility logic
-function canSeeGraph({ resultsDate, now, loggedIn, rcvisInfo }) {
-  var resultsVisible = !resultsDate || resultsDate < now;
-  var creatorWithKey = loggedIn && rcvisInfo && rcvisInfo.apiKey;
-  return resultsVisible || !!creatorWithKey;
-}
-
-// Replicate the post-cutoff vs open ballot branching
-function shouldUsePostCutoffPath({ voteCutoffDate, now }) {
-  return voteCutoffDate && voteCutoffDate < now;
-}
 
 describe('Graph staleness detection (post-cutoff path)', () => {
   it('is stale when graphUpdated is null', () => {
@@ -182,7 +162,7 @@ describe('Graph visibility for creator with key', () => {
     expect(canSeeGraph({
       resultsDate: new Date('2099-01-01'),
       now: new Date('2025-06-01'),
-      loggedIn: true,
+      isCreator: true,
       rcvisInfo: { apiKey: 'abc123' }
     })).toBe(true);
   });
@@ -191,7 +171,7 @@ describe('Graph visibility for creator with key', () => {
     expect(canSeeGraph({
       resultsDate: new Date('2099-01-01'),
       now: new Date('2025-06-01'),
-      loggedIn: false,
+      isCreator: false,
       rcvisInfo: null
     })).toBe(false);
   });
@@ -200,7 +180,7 @@ describe('Graph visibility for creator with key', () => {
     expect(canSeeGraph({
       resultsDate: new Date('2020-01-01'),
       now: new Date('2025-06-01'),
-      loggedIn: false,
+      isCreator: false,
       rcvisInfo: null
     })).toBe(true);
   });
@@ -209,7 +189,7 @@ describe('Graph visibility for creator with key', () => {
     expect(canSeeGraph({
       resultsDate: null,
       now: new Date('2025-06-01'),
-      loggedIn: false,
+      isCreator: false,
       rcvisInfo: null
     })).toBe(true);
   });
@@ -218,7 +198,7 @@ describe('Graph visibility for creator with key', () => {
     expect(canSeeGraph({
       resultsDate: new Date('2099-01-01'),
       now: new Date('2025-06-01'),
-      loggedIn: true,
+      isCreator: true,
       rcvisInfo: null
     })).toBe(false);
   });
@@ -227,7 +207,7 @@ describe('Graph visibility for creator with key', () => {
     expect(canSeeGraph({
       resultsDate: new Date('2099-01-01'),
       now: new Date('2025-06-01'),
-      loggedIn: true,
+      isCreator: true,
       rcvisInfo: {}
     })).toBe(false);
   });


### PR DESCRIPTION
## What
Moves four pure RCVis graph-display helpers out of [main.js](https://github.com/DavidMoritz/rcv/blob/feature/extract-rcvis-helpers/src/js/main.js) into [src/js/utils/rcvis-helpers.js](https://github.com/DavidMoritz/rcv/blob/feature/extract-rcvis-helpers/src/js/utils/rcvis-helpers.js), and rewires [test/rcvis-logic.test.js](https://github.com/DavidMoritz/rcv/blob/feature/extract-rcvis-helpers/test/rcvis-logic.test.js) to import them instead of redefining them.

## Why
The test file previously duplicated [shouldPatchGraph](https://github.com/DavidMoritz/rcv/blob/feature/extract-rcvis-helpers/src/js/utils/rcvis-helpers.js#L7-L13), [shouldAutoUpdate](https://github.com/DavidMoritz/rcv/blob/feature/extract-rcvis-helpers/src/js/utils/rcvis-helpers.js#L15-L33), [canSeeGraph](https://github.com/DavidMoritz/rcv/blob/feature/extract-rcvis-helpers/src/js/utils/rcvis-helpers.js#L35-L43), and [shouldUsePostCutoffPath](https://github.com/DavidMoritz/rcv/blob/feature/extract-rcvis-helpers/src/js/utils/rcvis-helpers.js#L45-L50) as standalone functions. That meant any future change to the production logic in [main.js](https://github.com/DavidMoritz/rcv/blob/feature/extract-rcvis-helpers/src/js/main.js) would silently drift from what the test verified — the test would keep passing while actually testing dead code.

## Changes
- New module: [src/js/utils/rcvis-helpers.js](https://github.com/DavidMoritz/rcv/blob/feature/extract-rcvis-helpers/src/js/utils/rcvis-helpers.js) exporting the four helpers
- [main.js](https://github.com/DavidMoritz/rcv/blob/feature/extract-rcvis-helpers/src/js/main.js) imports and calls them in [checkGraphStatus](https://github.com/DavidMoritz/rcv/blob/feature/extract-rcvis-helpers/src/js/main.js#L442-L466) and [evaluateGraph](https://github.com/DavidMoritz/rcv/blob/feature/extract-rcvis-helpers/src/js/main.js#L691-L727)
- [rcvis-logic.test.js](https://github.com/DavidMoritz/rcv/blob/feature/extract-rcvis-helpers/test/rcvis-logic.test.js) imports from the new module
- Renamed [canSeeGraph](https://github.com/DavidMoritz/rcv/blob/feature/extract-rcvis-helpers/src/js/utils/rcvis-helpers.js#L35-L43)'s `loggedIn` parameter to `isCreator` to match the actual production check (`$s.user.id == createdBy`)
- Dropped a now-unused `resultsVisible` local

## Verification
- Vitest: 132/132 ✅
- PHPUnit: 198/198 ✅
- CI green on this branch