### PR TITLE
Expand rcv-algorithm.test.js coverage

### DIFF
--- a/test/helpers/rcv-test-harness.js
+++ b/test/helpers/rcv-test-harness.js
@@ -44,6 +44,8 @@ export function buildVotes(ballots, candidates) {
  * @param {number} [opts.seats=1] - seats to fill
  * @param {string} [opts.tieBreak='weighted'] - 'weighted' or 'random'
  * @param {string} [opts.ballotName='Test Election'] - election name
+ * @param {boolean} [opts.patchRcvis=false] - when true, triggers the
+ *   transfer-diff computation and rcvis $.ajax call inside finishElection
  * @returns {{ elected: Object[], outputstring: string, jsonObj: Object }}
  */
 export function runElection(opts) {
@@ -52,7 +54,8 @@ export function runElection(opts) {
     ballots,
     seats = 1,
     tieBreak = 'weighted',
-    ballotName = 'Test Election'
+    ballotName = 'Test Election',
+    patchRcvis = false
   } = opts;
 
   const { entryMap, ids } = buildCandidates(candidateNames);
@@ -71,8 +74,7 @@ export function runElection(opts) {
     votes,
     mutableVotes,
     ballotName,
-    bbiBallot: false,
-    patchRcvis: false,
+    patchRcvis,
     rcvisId: null,
     rcvisSlug: null,
     ballotIsSecure: false,

--- a/test/rcv-algorithm.test.js
+++ b/test/rcv-algorithm.test.js
@@ -315,3 +315,168 @@ describe('RCV Algorithm — Edge Cases', () => {
     expect($.get).not.toHaveBeenCalled();
   });
 });
+
+describe('RCV Algorithm — Ballot Exhaustion', () => {
+  it('completes a multi-seat election where many ballots exhaust mid-round', () => {
+    // 7 single-rank ballots; after A wins, the 3 ['A'] ballots are exhausted
+    // (vote weight set to 0). Algorithm must continue to fill the 2nd seat
+    // from the remaining non-exhausted ballots.
+    const result = runElection({
+      candidates: ['A', 'B', 'C', 'D'],
+      ballots: [['A'], ['A'], ['A'], ['B'], ['B'], ['C'], ['D']],
+      seats: 2
+    });
+
+    expect(result.elected).toHaveLength(2);
+    const names = getWinnerNames(result);
+    expect(names).toContain('A');
+    expect(names).toContain('B');
+  });
+
+  it('terminates when all remaining ballots are exhausted before quota is met', () => {
+    // 1 seat. After C is elected (or eliminated) every remaining ballot
+    // has no next preference. The algorithm must not infinite-loop and must
+    // produce a winner (the last viable candidate).
+    const result = runElection({
+      candidates: ['A', 'B', 'C'],
+      ballots: [['C'], ['C'], ['A'], ['B']],
+      seats: 1
+    });
+
+    expect(result.elected).toHaveLength(1);
+    // C had the most first-choice votes; expected to win on tally even
+    // though A and B's ballots exhaust on elimination.
+    expect(getWinnerNames(result)).toEqual(['C']);
+  });
+});
+
+describe('RCV Algorithm — Tie Breaking (elimination path)', () => {
+  it('weighted tiebreak eliminates the candidate with weaker downstream support', () => {
+    // 4 votes, quota = 2. Round 1: A=2 (=quota, not strictly >), B=1, C=1.
+    // No winner; B and C tie at the bottom.
+    // - B's downstream value: 2 second-place mentions from A voters → 0.2
+    // - C's downstream value: 0
+    // Weighted "loser" sorts ascending → C (smaller value) is eliminated.
+    const result = runElection({
+      candidates: ['A', 'B', 'C'],
+      ballots: [
+        ['A', 'B'],
+        ['A', 'B'],
+        ['B', 'A'],
+        ['C']
+      ],
+      seats: 1,
+      tieBreak: 'weighted'
+    });
+
+    expect(result.jsonObj.results[0].tallyResults[0].eliminated).toBe('C');
+    expect(getWinnerNames(result)).toEqual(['A']);
+  });
+});
+
+describe('RCV Algorithm — Vote Weight After Surplus', () => {
+  it('reduces vote weight proportionally to surplus after a candidate is elected', () => {
+    // 4 ballots all ['A','B'], 2 seats. quota = round(4/3, 2) = 1.33.
+    // Round 1: A=4. Surplus weight multiplier = 1 - 1.33/4 = 0.6675.
+    // Round 2: each of the 4 ballots is now ['B'] with weight 0.6675.
+    //   B tally = 4 * 0.6675 = 2.67 (rounded to 4 decimals).
+    const result = runElection({
+      candidates: ['A', 'B'],
+      ballots: [
+        ['A', 'B'],
+        ['A', 'B'],
+        ['A', 'B'],
+        ['A', 'B']
+      ],
+      seats: 2
+    });
+
+    expect(getWinnerNames(result)).toEqual(['A', 'B']);
+    // jsonObj stores tally values as strings (cand.vote + '')
+    const r2BTally = Number(result.jsonObj.results[1].tally.B);
+    expect(r2BTally).toBeCloseTo(2.67, 2);
+  });
+});
+
+describe('RCV Algorithm — Seats Clamping', () => {
+  it('clamps seats to number of candidates when seats > candidates', () => {
+    // firstQuota: this.seats = Math.min(this.seats, $s.ids.length).
+    // Asking for 5 seats with only 2 candidates → both elected, no crash.
+    const result = runElection({
+      candidates: ['A', 'B'],
+      ballots: [
+        ['A', 'B'],
+        ['B', 'A'],
+        ['A', 'B']
+      ],
+      seats: 5
+    });
+
+    expect(result.elected).toHaveLength(2);
+    const names = getWinnerNames(result);
+    expect(names).toContain('A');
+    expect(names).toContain('B');
+  });
+});
+
+describe('RCV Algorithm — Multi-Seat (3 seats)', () => {
+  it('elects 3 winners exercising renewQuota across multiple rounds', () => {
+    // 3 seats, 8 votes. Initial quota = 8/4 = 2. After A is elected with
+    // surplus, renewQuota recomputes based on remaining vote value, and
+    // the algorithm continues to fill 2 more seats.
+    const result = runElection({
+      candidates: ['A', 'B', 'C', 'D'],
+      ballots: [
+        ['A', 'B', 'C'],
+        ['A', 'B', 'C'],
+        ['A', 'C', 'D'],
+        ['B', 'C'],
+        ['B', 'D'],
+        ['C', 'A'],
+        ['C', 'B'],
+        ['D', 'A']
+      ],
+      seats: 3
+    });
+
+    expect(result.elected).toHaveLength(3);
+    expect(getWinnerNames(result)).toContain('A');
+    // The 3-seat election should have multiple rounds recorded.
+    expect(result.jsonObj.results.length).toBeGreaterThan(1);
+  });
+});
+
+describe('RCV Algorithm — patchRcvis output', () => {
+  it('populates per-round transfer diffs and posts to rcvis_new when patchRcvis is true', () => {
+    // Two-round single-seat election. With patchRcvis=true, finishElection
+    // computes a `transfers` map on each non-final round's tallyResults[0]
+    // showing how vote counts shifted into the next round.
+    const result = runElection({
+      candidates: ['A', 'B', 'C'],
+      ballots: [
+        ['A', 'B'],
+        ['A'],
+        ['B', 'C'],
+        ['B', 'A'],
+        ['C', 'A']
+      ],
+      seats: 1,
+      patchRcvis: true
+    });
+
+    // Round 1 has a next-round, so transfers should be populated.
+    const transfers = result.jsonObj.results[0].tallyResults[0].transfers;
+    expect(transfers).toBeDefined();
+    expect(typeof transfers).toBe('object');
+    // Transfer values are strings (newVotes - oldVotes or absolute).
+    Object.values(transfers).forEach((val) => {
+      expect(typeof val).toBe('string');
+    });
+
+    // rcvisId/rcvisSlug were null, so the post goes to rcvis_new.php.
+    expect($.ajax).toHaveBeenCalled();
+    const call = $.ajax.mock.calls[0][0];
+    expect(call.url).toContain('/api/rcvis_new.php');
+    expect(call.type).toBe('POST');
+  });
+});


### PR DESCRIPTION
## Summary

Adds 7 tests across 6 new `describe` blocks to `test/rcv-algorithm.test.js`, closing documented coverage gaps in the RCV algorithm. No production code changes — tests only, plus a small harness update.

## What's new

### `test/rcv-algorithm.test.js` — 7 new tests

| Block | Gap closed |
|---|---|
| **Ballot Exhaustion** (2 tests) | Multi-seat with heavy mid-round exhaustion; edge case where all remaining ballots exhaust before quota is met. |
| **Tie Breaking (elimination path)** | `breakTieWeighted` with `isLoser=true` (previously the existing tiebreak test only covered the election path). |
| **Vote Weight After Surplus** | Numeric assertion on next-round tally (`B ≈ 2.67`), verifying the proportional weight-reduction math in `removeChosen`. |
| **Seats Clamping** | `firstQuota`'s `Math.min(seats, candidates)` guard when `seats > candidates`. |
| **Multi-Seat (3 seats)** | Exercises `renewQuota` across multiple rounds. |
| **patchRcvis output** | Per-round transfer-diff JSON construction in `finishElection` and the POST to `/api/rcvis_new.php`. |

### `test/helpers/rcv-test-harness.js` — small additions

- Add `patchRcvis` option (defaults to `false`; threaded into the mock scope).
- Drop the unused `bbiBallot: false` field. The `bbiBallot` scope variable was removed from production in commit `0109ca7` ("RCVis graph overhaul: ... BBI removal") and is no longer referenced anywhere in `src/`.

## Out of scope (deferred)

- **Property-based tests with `fast-check`** — introduces a new dev dependency and a different testing style. Worth its own PR.
- **Random-tiebreak behavioral assertions** (vs. the existing determinism-only test) — would benefit from a seeded RNG seam.
- **Malformed ballot inputs** (duplicate ranks within a ballot, invalid candidate IDs) — low priority; the UI normalizes these before they reach the algorithm.

## Verification

- Vitest: **132 → 139 passing**, 0 failing
- PHPUnit: **198/198 passing** (unchanged — no PHP touched)

```
$ npm test
...
Test Files  7 passed (7)
     Tests  139 passed (139)
...
OK (198 tests, 461 assertions)
```
