### PR TITLE
Fix local setup paper cuts

### DIFF
--- a/src/api/SETUP.md
+++ b/src/api/SETUP.md
@@ -15,6 +15,15 @@ The fastest way to set up your database is to run the production schema script:
 mysql -u root -p < src/api/setup-database-prod.sql
 ```
 
+The schema script is intended for a new local database. If you need to re-run it
+against an existing local setup, drop the database first. This deletes all local
+RCV data:
+
+```bash
+mysql -u root -p -e "DROP DATABASE IF EXISTS rcv_db;"
+mysql -u root -p < src/api/setup-database-prod.sql
+```
+
 This will:
 - Create the `rcv_db` database
 - Create the `rcv_user` with password `rcv_password`
@@ -78,16 +87,19 @@ mysql -u rcv_user -p'rcv_password' rcv_db -e "SHOW TABLES;"
 You should see:
 
 ```
-+------------------+
-| Tables_in_rcv_db |
-+------------------+
-| ballots          |
-| contributions    |
-| entries          |
-| random_codes     |
-| users            |
-| votes            |
-+------------------+
++-----------------------+
+| Tables_in_rcv_db      |
++-----------------------+
+| ballot_codes          |
+| ballots               |
+| contributions         |
+| entries               |
+| random_codes          |
+| users                 |
+| voter_group_fields    |
+| voter_group_options   |
+| votes                 |
++-----------------------+
 ```
 
 ## Create Config File

--- a/start-local.sh
+++ b/start-local.sh
@@ -6,7 +6,14 @@ set -e
 
 cd "$(dirname "$0")"
 
-MYSQL="/usr/local/mysql/bin/mysql"
+MYSQL="${MYSQL:-$(command -v mysql || true)}"
+if [ -z "$MYSQL" ] && [ -x "/usr/local/mysql/bin/mysql" ]; then
+  MYSQL="/usr/local/mysql/bin/mysql"
+fi
+if [ -z "$MYSQL" ]; then
+  echo "Could not find mysql. Install MySQL or set MYSQL=/path/to/mysql."
+  exit 1
+fi
 DB_USER="rcv_user"
 DB_PASS="rcv_password"
 DB_NAME="rcv_db"


### PR DESCRIPTION
## Summary
- document the destructive drop step before re-running the local production schema setup
- update the setup verification table list to include all 9 current schema tables
- resolve the mysql client from PATH in start-local.sh, with the old Intel Mac path as a fallback

## Tests
- bash -n start-local.sh
- git diff --check