### PR TITLE
Add Playwright happy-path E2E

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "less": "^4.2.0",
         "vite": "^5.0.12",
         "vite-plugin-static-copy": "^1.0.0",
-        "vitest": "^4.1.5"
+        "vitest": "^4.1.5",
+        "@playwright/test": "^1.60.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -3923,6 +3924,69 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "build:prod": "vite build && cp src/api/config.prod.php dist/api/config.php",
     "preview": "vite preview",
     "test": "vitest run && ./vendor/bin/phpunit",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:setup-db": "node test/e2e/db.mjs setup",
+    "test:e2e:teardown-db": "node test/e2e/db.mjs teardown"
   },
   "dependencies": {
     "angular": "^1.5.3",
@@ -26,6 +29,7 @@
     "ng-pattern-restrict": "^0.2.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "angular-mocks": "^1.8.3",
     "jsdom": "^29.1.0",
     "less": "^4.2.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.E2E_BASE_URL || 'http://127.0.0.1:2460';
+
+export default defineConfig({
+  testDir: './test/e2e',
+  globalSetup: './test/e2e/global-setup.mjs',
+  globalTeardown: './test/e2e/global-teardown.mjs',
+  fullyParallel: false,
+  workers: 1,
+  timeout: 45_000,
+  expect: {
+    timeout: 10_000
+  },
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure'
+  },
+  webServer: [
+    {
+      command: 'node test/e2e/prepare-php-server.mjs && php -S 127.0.0.1:2461 -t .cache/e2e-php',
+      url: 'http://127.0.0.1:2461/api/get-candidates.php',
+      reuseExistingServer: false,
+      timeout: 120_000
+    },
+    {
+      command: 'npm run dev -- --host 127.0.0.1',
+      url: baseURL,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000
+    }
+  ],
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    }
+  ]
+});

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,6 +1,31 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const baseURL = process.env.E2E_BASE_URL || 'http://127.0.0.1:2460';
+function sanitizeRunId(value) {
+  return value.replace(/[^a-zA-Z0-9_]/g, '_').slice(0, 32);
+}
+
+function hashToPort(value, offset) {
+  let hash = 0;
+  for (const char of value) {
+    hash = (hash * 31 + char.charCodeAt(0)) % 10_000;
+  }
+  return 20_000 + offset + hash;
+}
+
+const runId = sanitizeRunId(process.env.E2E_RUN_ID || `${Date.now()}_${process.pid}`);
+const phpPort = process.env.E2E_PHP_PORT || String(hashToPort(runId, 0));
+const vitePort = process.env.E2E_VITE_PORT || String(hashToPort(runId, 10_000));
+const phpRoot = process.env.E2E_PHP_ROOT || `.cache/e2e-php-${runId}`;
+const baseURL = process.env.E2E_BASE_URL || `http://127.0.0.1:${vitePort}`;
+
+Object.assign(process.env, {
+  E2E_RUN_ID: runId,
+  E2E_DB_NAME: process.env.E2E_DB_NAME || `rcv_e2e_${runId}`,
+  E2E_PHP_PORT: phpPort,
+  E2E_VITE_PORT: vitePort,
+  E2E_PHP_ROOT: phpRoot,
+  E2E_BASE_URL: baseURL
+});
 
 export default defineConfig({
   testDir: './test/e2e',
@@ -19,13 +44,13 @@ export default defineConfig({
   },
   webServer: [
     {
-      command: 'node test/e2e/prepare-php-server.mjs && php -S 127.0.0.1:2461 -t .cache/e2e-php',
-      url: 'http://127.0.0.1:2461/api/get-candidates.php',
+      command: `node test/e2e/prepare-php-server.mjs && php -S 127.0.0.1:${phpPort} -t ${phpRoot}`,
+      url: `http://127.0.0.1:${phpPort}/api/get-candidates.php`,
       reuseExistingServer: false,
       timeout: 120_000
     },
     {
-      command: 'npm run dev -- --host 127.0.0.1',
+      command: `npm run dev -- --host 127.0.0.1 --port ${vitePort}`,
       url: baseURL,
       reuseExistingServer: !process.env.CI,
       timeout: 120_000

--- a/src/pages/create.html
+++ b/src/pages/create.html
@@ -1,4 +1,4 @@
-<div ng-show="activeLink == 'create'" class="panel panel-default">
+<div ng-show="activeLink == 'create'" class="panel panel-default" data-testid="create-view">
   <div class="panel-body">
     <h1><span ng-show="editBallot">Edit </span>Ballot: {{ballot.name}}</h1>
     <div ng-show="editBallot" class="form-group">
@@ -16,7 +16,12 @@
     >
       <div class="form-group">
         <label>Ballot Name</label>
-        <input name="name" ng-model="ballot.name" class="form-control" /><span
+        <input
+          name="name"
+          ng-model="ballot.name"
+          class="form-control"
+          data-testid="ballot-name-input"
+        /><span
           ng-show="errors.name"
           class="text-danger"
           >{{errors.name}}</span
@@ -33,6 +38,7 @@
             ng-change="checkAvailability()"
             maxlength="16"
             class="form-control"
+            data-testid="ballot-key-input"
           /><span class="input-group-btn">
             <button type="button" ng-click="generateRandomKey()" class="btn btn-primary">
               New Shortcode
@@ -524,7 +530,13 @@
           </div>
         </div>
       </div>
-      <input type="submit" value="Submit" ng-disabled="errors.key" class="btn btn-info" />
+      <input
+        type="submit"
+        value="Submit"
+        ng-disabled="errors.key"
+        class="btn btn-info"
+        data-testid="ballot-submit"
+      />
     </form>
     <div ng-show="entries &amp;&amp; !congrats &amp;&amp; !showGroupPage">
       <div ng-show="!editBallot || editBallot_Options == 'false'">
@@ -536,16 +548,22 @@
               ng-model="entryInput"
               ng-change="errorEntry = ''"
               class="form-control"
+              data-testid="entry-input"
             /><span ng-show="errorEntry">{{errorEntry}}</span>
           </div>
-          <button type="submit" class="btn btn-info">Add Entry</button>
-          <button type="button" ng-click="submitEntries()" class="btn btn-default">
+          <button type="submit" class="btn btn-info" data-testid="entry-add">Add Entry</button>
+          <button
+            type="button"
+            ng-click="submitEntries()"
+            class="btn btn-default"
+            data-testid="entries-submit"
+          >
             <span ng-show="ballot.allowGrouping">Next: Voter Prompts</span>
             <span ng-hide="ballot.allowGrouping">Submit All Entries</span>
           </button>
         </form>
         <h2>Current Entry List</h2>
-        <h5 ng-repeat="entry in entries track by $index">
+        <h5 ng-repeat="entry in entries track by $index" data-testid="entry-list-item">
           <div
             style="display: inline-block"
             ng-style="entryColors[$index] ? {'background-color': '#' + entryColors[$index], 'padding': '2px 6px', 'border-radius': '4px'} : {}"
@@ -717,13 +735,16 @@
         Submit Voter Prompts
       </button>
     </div>
-    <div ng-show="congrats">
+    <div ng-show="congrats" data-testid="ballot-created">
       <div class="row">
         <div class="col-sm-6">
           <h3>Thank you for creating a ballot!</h3>
           <h4>Send this url or QR code to people for voting:</h4>
           <h4 class="text-success">{{origin}}/{{ballot.key}}</h4>
-          <a ng-hide="ballot.isSecure" href="{{origin}}/vote#{{ballot.key}}"
+          <a
+            ng-hide="ballot.isSecure"
+            href="{{origin}}/vote#{{ballot.key}}"
+            data-testid="vote-self-link"
             >Click here to vote yourself</a
           >
           <a ng-show="ballot.isSecure" href="{{origin}}/profile"

--- a/src/pages/results.html
+++ b/src/pages/results.html
@@ -1,4 +1,4 @@
-      <div ng-show="activeLink == 'results'" class="panel panel-default">
+      <div ng-show="activeLink == 'results'" class="panel panel-default" data-testid="results-view">
         <div class="panel-body">
           <div ng-hide="final">
             <div class="row">
@@ -38,13 +38,14 @@
               </div>
             </div>
           </div>
-          <div ng-show="final">
+          <div ng-show="final" data-testid="results-final">
             <div ng-show="elected[0].image" class="pull-right">
               <img ng-src="{{elected[0].image}}" class="winner-image" />
             </div>
-            <h1>Results<span class="ballot-name"></span></h1>
+            <h1 data-testid="results-title">Results<span class="ballot-name"></span></h1>
             <h2 ng-show="elected.length == 1">
-              The winner<span ng-if="!voteClosed"> (so far)</span>: {{elected[0].name}}
+              The winner<span ng-if="!voteClosed"> (so far)</span>:
+              <span data-testid="results-winner-name">{{elected[0].name}}</span>
             </h2>
             <div ng-show="elected.length > 1">
               <h2>

--- a/src/pages/vote.html
+++ b/src/pages/vote.html
@@ -1,4 +1,4 @@
-<div ng-show="activeLink == 'vote'" class="panel panel-default">
+<div ng-show="activeLink == 'vote'" class="panel panel-default" data-testid="vote-view">
   <div class="panel-body">
     <div ng-hide="candidates">
       <div class="row">
@@ -33,7 +33,7 @@
       ng-if="candidates && ballot.isSecure && !secureCodeValid"
       ng-hide="thanks || deviceAlreadyVoted"
     >
-      <h1>Ballot: {{ballot.name}}</h1>
+      <h1 data-testid="vote-ballot-title">Ballot: {{ballot.name}}</h1>
       <h3>Enter your voter code to proceed</h3>
       <form ng-submit="validateSecureCode()">
         <div class="form-group" style="max-width: 300px">
@@ -55,7 +55,7 @@
       ng-if="candidates && ballot.allowGrouping && !groupAnswersSubmitted && (!ballot.isSecure || secureCodeValid)"
       ng-hide="thanks || deviceAlreadyVoted"
     >
-      <h1>Ballot: {{ballot.name}}</h1>
+      <h1 data-testid="vote-ballot-title">Ballot: {{ballot.name}}</h1>
       <form ng-submit="submitGroupAnswers()">
         <div ng-hide="ballot.register == 2 || ballot.isSecure" style="margin-bottom: 15px">
           <label for="voter-name">Your Name<span ng-show="ballot.register == 1">*</span>:</label>
@@ -125,7 +125,7 @@
       ng-if="candidates && (!ballot.isSecure || secureCodeValid) && (!ballot.allowGrouping || groupAnswersSubmitted)"
       ng-hide="thanks || deviceAlreadyVoted"
     >
-      <h1>Ballot: {{ballot.name}}</h1>
+      <h1 data-testid="vote-ballot-title">Ballot: {{ballot.name}}</h1>
       <div
         ng-if="voteCutoffMoment && cutoffSecondsLeft > 0 && cutoffSecondsLeft <= 300"
         class="alert alert-warning"
@@ -197,6 +197,7 @@
               ng-repeat="item in candidates track by $index"
               data-id="{{item.id}}"
               class="candidate-item"
+              data-testid="vote-candidate"
               ng-style="item.color ? {'background-color': '#' + item.color} : {}"
             >
               <i ng-click="removeCandidate($index)" class="fa fa-trash remove-btn"></i>
@@ -214,6 +215,7 @@
             type="submit"
             ng-disabled="candidates.length === 0 || (voteCutoffMoment && cutoffSecondsLeft <= 0)"
             class="btn btn-primary clearfix"
+            data-testid="vote-submit"
           >
             Vote!
           </button>
@@ -222,11 +224,11 @@
       </div>
       <h4>Voting URL: {{origin}}/{{ballot.key}}</h4>
     </div>
-    <div ng-show="thanks">
-      <h1>Ballot: {{ballot.name}}</h1>
+    <div ng-show="thanks" data-testid="vote-thanks">
+      <h1 data-testid="vote-ballot-title">Ballot: {{ballot.name}}</h1>
       <h3>Thank you for voting!</h3>
       <h4 ng-if="resultsReady">
-        <a href="/results#{{shortcode}}">Click here to see the results</a>
+        <a href="/results#{{shortcode}}" data-testid="results-link">Click here to see the results</a>
       </h4>
       <h5 ng-if="ballot.isSecure && !resultsReady">
         Visit <a href="/results#{{shortcode}}">{{origin}}/results#{{ballot.key}}</a> after
@@ -246,7 +248,7 @@
       </p>
     </div>
     <div ng-show="deviceAlreadyVoted">
-      <h1>Ballot: {{ballot.name}}</h1>
+      <h1 data-testid="vote-ballot-title">Ballot: {{ballot.name}}</h1>
       <h3>This device has already voted on this ballot.</h3>
       <p>
         Each device is limited to one vote. If you believe this is an error, please contact the

--- a/src/pages/vote.html
+++ b/src/pages/vote.html
@@ -124,6 +124,7 @@
     <div
       ng-if="candidates && (!ballot.isSecure || secureCodeValid) && (!ballot.allowGrouping || groupAnswersSubmitted)"
       ng-hide="thanks || deviceAlreadyVoted"
+      data-testid="vote-ballot-form"
     >
       <h1 data-testid="vote-ballot-title">Ballot: {{ballot.name}}</h1>
       <div
@@ -208,7 +209,7 @@
                 ng-if="item.hyperlink"
                 >{{item.name}} <i class="fa fa-external-link"></i
               ></a>
-              <div ng-if="!item.hyperlink">{{item.name}}</div>
+              <div ng-if="!item.hyperlink" data-testid="vote-candidate-name">{{item.name}}</div>
             </li>
           </ul>
           <button

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,7 +1,7 @@
 # Playwright E2E Tests
 
 These tests run against the real Vite app and real PHP API, but use an isolated
-MySQL database named `rcv_e2e` by default.
+MySQL database named `rcv_e2e_<runId>` by default.
 
 ## Commands
 
@@ -25,16 +25,20 @@ E2E_DB_ADMIN_USER=root
 E2E_DB_ADMIN_PASSWORD=
 E2E_DB_ADMIN_HOST=localhost
 E2E_DB_ADMIN_PORT=3306
-E2E_DB_NAME=rcv_e2e
+E2E_DB_NAME=rcv_e2e_<runId>
 E2E_DB_USER=rcv_e2e_user
 E2E_DB_PASSWORD=rcv_e2e_password
 E2E_DB_HOST=localhost
 E2E_DB_PORT=3306
 ```
 
-The PHP server uses an ignored temporary copy of `src/` at `.cache/e2e-php`
-with an E2E-only `api/config.php`, so your normal `src/api/config.php` is not
-read or modified.
+`npm run test:e2e` overrides `E2E_DB_NAME` with a run-specific value by
+default, while `npm run test:e2e:setup-db` and `npm run test:e2e:teardown-db`
+still use the config values you set here.
+
+The PHP server uses an ignored temporary copy of `src/` at
+`.cache/e2e-php-<runId>` with an E2E-only `api/config.php`, so your normal
+`src/api/config.php` is not read or modified.
 
 ## CI and Parallel Runs
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,37 @@
+# Playwright E2E Tests
+
+These tests run against the real Vite app and real PHP API, but use an isolated
+MySQL database named `rcv_e2e` by default.
+
+## Commands
+
+```bash
+npm run test:e2e
+npm run test:e2e:setup-db
+npm run test:e2e:teardown-db
+```
+
+`npm run test:e2e` drops and recreates the E2E database during global setup and
+drops it again during global teardown. Set `E2E_KEEP_DB=1` to leave the database
+behind for debugging.
+
+## MySQL Configuration
+
+The setup script connects as a MySQL admin user to create the database and grant
+the app user access. Defaults match the local setup docs:
+
+```bash
+E2E_DB_ADMIN_USER=root
+E2E_DB_ADMIN_PASSWORD=
+E2E_DB_ADMIN_HOST=localhost
+E2E_DB_ADMIN_PORT=3306
+E2E_DB_NAME=rcv_e2e
+E2E_DB_USER=rcv_e2e_user
+E2E_DB_PASSWORD=rcv_e2e_password
+E2E_DB_HOST=localhost
+E2E_DB_PORT=3306
+```
+
+The PHP server uses an ignored temporary copy of `src/` at `.cache/e2e-php`
+with an E2E-only `api/config.php`, so your normal `src/api/config.php` is not
+read or modified.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -35,3 +35,17 @@ E2E_DB_PORT=3306
 The PHP server uses an ignored temporary copy of `src/` at `.cache/e2e-php`
 with an E2E-only `api/config.php`, so your normal `src/api/config.php` is not
 read or modified.
+
+## CI and Parallel Runs
+
+`npm run test:e2e` generates a run-specific database name, PHP copy directory,
+and local ports by default. CI can set these values explicitly when a runner
+needs deterministic names:
+
+```bash
+E2E_RUN_ID=ci_123
+E2E_DB_NAME=rcv_e2e_ci_123
+E2E_PHP_PORT=2461
+E2E_VITE_PORT=2460
+E2E_PHP_ROOT=.cache/e2e-php-ci-123
+```

--- a/test/e2e/db.mjs
+++ b/test/e2e/db.mjs
@@ -1,0 +1,100 @@
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const modulePath = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(modulePath), '../..');
+const schemaPath = path.join(repoRoot, 'src/api/setup-database-prod.sql');
+
+const config = {
+  adminUser: process.env.E2E_DB_ADMIN_USER || 'root',
+  adminPassword: process.env.E2E_DB_ADMIN_PASSWORD || '',
+  adminHost: process.env.E2E_DB_ADMIN_HOST || 'localhost',
+  adminPort: process.env.E2E_DB_ADMIN_PORT || '3306',
+  appUser: process.env.E2E_DB_USER || 'rcv_e2e_user',
+  appPassword: process.env.E2E_DB_PASSWORD || 'rcv_e2e_password',
+  appHost: process.env.E2E_DB_HOST || 'localhost',
+  appPort: process.env.E2E_DB_PORT || '3306',
+  dbName: process.env.E2E_DB_NAME || 'rcv_e2e'
+};
+
+function quoteIdent(value) {
+  if (!/^[a-zA-Z0-9_]+$/.test(value)) {
+    throw new Error(`Unsafe MySQL identifier for E2E database: ${value}`);
+  }
+  return `\`${value}\``;
+}
+
+function sqlString(value) {
+  return `'${String(value).replace(/\\/g, '\\\\').replace(/'/g, "''")}'`;
+}
+
+function mysqlArgs() {
+  const args = ['-h', config.adminHost, '-P', config.adminPort, '-u', config.adminUser];
+  if (config.adminPassword) {
+    args.push(`-p${config.adminPassword}`);
+  }
+  return args;
+}
+
+async function runMysql(sql) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(process.env.MYSQL || 'mysql', mysqlArgs(), {
+      cwd: repoRoot,
+      stdio: ['pipe', 'inherit', 'inherit']
+    });
+
+    child.stdin.end(sql);
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`mysql exited with code ${code}`));
+      }
+    });
+  });
+}
+
+async function schemaTablesSql() {
+  const schema = await readFile(schemaPath, 'utf8');
+  const start = schema.indexOf('/*!40101 SET @OLD_CHARACTER_SET_CLIENT');
+  if (start === -1) {
+    throw new Error('Could not find start of table schema in setup-database-prod.sql');
+  }
+  return schema.slice(start);
+}
+
+export async function setupDatabase() {
+  const dbName = quoteIdent(config.dbName);
+  const tables = await schemaTablesSql();
+  await runMysql(`
+DROP DATABASE IF EXISTS ${dbName};
+CREATE DATABASE ${dbName} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE USER IF NOT EXISTS ${sqlString(config.appUser)}@${sqlString(config.appHost)} IDENTIFIED BY ${sqlString(config.appPassword)};
+GRANT ALL PRIVILEGES ON ${dbName}.* TO ${sqlString(config.appUser)}@${sqlString(config.appHost)};
+FLUSH PRIVILEGES;
+USE ${dbName};
+${tables}
+`);
+}
+
+export async function teardownDatabase() {
+  if (process.env.E2E_KEEP_DB === '1') {
+    return;
+  }
+
+  await runMysql(`DROP DATABASE IF EXISTS ${quoteIdent(config.dbName)};`);
+}
+
+if (process.argv[1] === modulePath) {
+  const command = process.argv[2];
+  if (command === 'setup') {
+    await setupDatabase();
+  } else if (command === 'teardown') {
+    await teardownDatabase();
+  } else if (command) {
+    throw new Error(`Unknown E2E database command: ${command}`);
+  }
+}

--- a/test/e2e/global-setup.mjs
+++ b/test/e2e/global-setup.mjs
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
-const readyFile = path.join(repoRoot, '.cache/e2e-db-ready');
+const readyFile = path.join(repoRoot, '.cache', `e2e-db-ready-${process.env.E2E_RUN_ID || 'default'}`);
 
 export default async function globalSetup() {
   await setupDatabase();

--- a/test/e2e/global-setup.mjs
+++ b/test/e2e/global-setup.mjs
@@ -1,0 +1,13 @@
+import { setupDatabase } from './db.mjs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const readyFile = path.join(repoRoot, '.cache/e2e-db-ready');
+
+export default async function globalSetup() {
+  await setupDatabase();
+  await mkdir(path.dirname(readyFile), { recursive: true });
+  await writeFile(readyFile, 'ready\n', 'utf8');
+}

--- a/test/e2e/global-teardown.mjs
+++ b/test/e2e/global-teardown.mjs
@@ -1,0 +1,18 @@
+import { teardownDatabase } from './db.mjs';
+import { access, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const readyFile = path.join(repoRoot, '.cache/e2e-db-ready');
+
+export default async function globalTeardown() {
+  try {
+    await access(readyFile);
+  } catch {
+    return;
+  }
+
+  await teardownDatabase();
+  await rm(readyFile, { force: true });
+}

--- a/test/e2e/global-teardown.mjs
+++ b/test/e2e/global-teardown.mjs
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
-const readyFile = path.join(repoRoot, '.cache/e2e-db-ready');
+const readyFile = path.join(repoRoot, '.cache', `e2e-db-ready-${process.env.E2E_RUN_ID || 'default'}`);
 
 export default async function globalTeardown() {
   try {

--- a/test/e2e/happy-path.spec.js
+++ b/test/e2e/happy-path.spec.js
@@ -10,33 +10,38 @@ test('creates a ballot, casts a vote, and renders results', async ({ page }) => 
   const ballotName = `E2E Happy Path ${suffix}`;
 
   await page.goto('/create');
-  await expect(page.getByTestId('create-view')).toBeVisible();
+  const createView = page.getByTestId('create-view');
+  await expect(createView).toBeVisible();
 
-  await page.getByTestId('ballot-name-input').fill(ballotName);
-  await page.getByTestId('ballot-key-input').fill(shortcode);
-  await page.getByTestId('ballot-submit').click();
+  await createView.getByTestId('ballot-name-input').fill(ballotName);
+  await createView.getByTestId('ballot-key-input').fill(shortcode);
+  await createView.getByTestId('ballot-submit').click();
 
-  const entryInput = page.getByTestId('entry-input');
+  const entryInput = createView.getByTestId('entry-input');
   await expect(entryInput).toBeVisible();
   for (const entry of ['Ada', 'Grace', 'Katherine']) {
     await entryInput.fill(entry);
-    await page.getByTestId('entry-add').click();
+    await createView.getByTestId('entry-add').click();
   }
-  await expect(page.getByTestId('entry-list-item')).toHaveCount(3);
+  await expect(createView.getByTestId('entry-list-item')).toHaveCount(3);
 
-  await page.getByTestId('entries-submit').click();
-  await expect(page.getByTestId('ballot-created')).toBeVisible();
+  await createView.getByTestId('entries-submit').click();
+  await expect(createView.getByTestId('ballot-created')).toBeVisible();
 
-  await page.getByTestId('vote-self-link').click();
-  await expect(page.getByTestId('vote-ballot-title').filter({ visible: true })).toContainText(ballotName);
-  const visibleCandidates = page.getByTestId('vote-candidate').filter({ visible: true });
-  await expect(visibleCandidates).toHaveCount(3);
-  const firstChoice = (await visibleCandidates.first().textContent()).trim();
-  await page.getByTestId('vote-submit').click();
+  await createView.getByTestId('vote-self-link').click();
+  const voteView = page.getByTestId('vote-view');
+  const ballotForm = voteView.getByTestId('vote-ballot-form');
+  await expect(ballotForm.getByTestId('vote-ballot-title')).toContainText(ballotName);
+  const candidates = ballotForm.getByTestId('vote-candidate');
+  await expect(candidates).toHaveCount(3);
+  const firstChoice = await candidates.first().getByTestId('vote-candidate-name').innerText();
+  await ballotForm.getByTestId('vote-submit').click();
 
-  await expect(page.getByTestId('vote-thanks').filter({ visible: true })).toBeVisible();
-  await page.getByTestId('results-link').filter({ visible: true }).click();
+  await expect(voteView.getByTestId('vote-thanks')).toBeVisible();
+  await voteView.getByTestId('results-link').click();
 
-  await expect(page.getByTestId('results-final').filter({ visible: true })).toBeVisible();
-  await expect(page.getByTestId('results-winner-name').filter({ visible: true })).toHaveText(firstChoice);
+  const resultsView = page.getByTestId('results-view');
+  const finalResults = resultsView.getByTestId('results-final');
+  await expect(finalResults).toBeVisible();
+  await expect(finalResults.getByTestId('results-winner-name')).toHaveText(firstChoice);
 });

--- a/test/e2e/happy-path.spec.js
+++ b/test/e2e/happy-path.spec.js
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+
+test('creates a ballot, casts a vote, and renders results', async ({ page }) => {
+  await page.route(/^https?:\/\/(?!(127\.0\.0\.1|localhost)(:\d+)?\/).*/, (route) => {
+    route.abort();
+  });
+
+  const suffix = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+  const shortcode = `e2e${suffix}`;
+  const ballotName = `E2E Happy Path ${suffix}`;
+
+  await page.goto('/create');
+  await expect(page.getByTestId('create-view')).toBeVisible();
+
+  await page.getByTestId('ballot-name-input').fill(ballotName);
+  await page.getByTestId('ballot-key-input').fill(shortcode);
+  await page.getByTestId('ballot-submit').click();
+
+  const entryInput = page.getByTestId('entry-input');
+  await expect(entryInput).toBeVisible();
+  for (const entry of ['Ada', 'Grace', 'Katherine']) {
+    await entryInput.fill(entry);
+    await page.getByTestId('entry-add').click();
+  }
+  await expect(page.getByTestId('entry-list-item')).toHaveCount(3);
+
+  await page.getByTestId('entries-submit').click();
+  await expect(page.getByTestId('ballot-created')).toBeVisible();
+
+  await page.getByTestId('vote-self-link').click();
+  await expect(page.getByTestId('vote-ballot-title').filter({ visible: true })).toContainText(ballotName);
+  const visibleCandidates = page.getByTestId('vote-candidate').filter({ visible: true });
+  await expect(visibleCandidates).toHaveCount(3);
+  const firstChoice = (await visibleCandidates.first().textContent()).trim();
+  await page.getByTestId('vote-submit').click();
+
+  await expect(page.getByTestId('vote-thanks').filter({ visible: true })).toBeVisible();
+  await page.getByTestId('results-link').filter({ visible: true }).click();
+
+  await expect(page.getByTestId('results-final').filter({ visible: true })).toBeVisible();
+  await expect(page.getByTestId('results-winner-name').filter({ visible: true })).toHaveText(firstChoice);
+});

--- a/test/e2e/prepare-php-server.mjs
+++ b/test/e2e/prepare-php-server.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const sourceDir = path.join(repoRoot, 'src');
-const targetDir = path.join(repoRoot, '.cache/e2e-php');
+const targetDir = path.resolve(repoRoot, process.env.E2E_PHP_ROOT || '.cache/e2e-php');
 const apiConfigPath = path.join(targetDir, 'api/config.php');
 
 const dbHost = process.env.E2E_DB_HOST || 'localhost';

--- a/test/e2e/prepare-php-server.mjs
+++ b/test/e2e/prepare-php-server.mjs
@@ -1,0 +1,47 @@
+import { cp, mkdir, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const sourceDir = path.join(repoRoot, 'src');
+const targetDir = path.join(repoRoot, '.cache/e2e-php');
+const apiConfigPath = path.join(targetDir, 'api/config.php');
+
+const dbHost = process.env.E2E_DB_HOST || 'localhost';
+const dbPort = process.env.E2E_DB_PORT || '3306';
+const dbUser = process.env.E2E_DB_USER || 'rcv_e2e_user';
+const dbPassword = process.env.E2E_DB_PASSWORD || 'rcv_e2e_password';
+const dbName = process.env.E2E_DB_NAME || 'rcv_e2e';
+
+function phpString(value) {
+  return `'${String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+await rm(targetDir, { recursive: true, force: true });
+await cp(sourceDir, targetDir, {
+  recursive: true,
+  filter: (source) => path.basename(source) !== 'config.php' && path.basename(source) !== 'config.prod.php'
+});
+
+await mkdir(path.dirname(apiConfigPath), { recursive: true });
+await writeFile(
+  apiConfigPath,
+  `<?php
+if (defined('PHPUNIT_RUNNING')) return;
+
+define('SERVER', ${phpString(`${dbHost}:${dbPort}`)});
+define('USERNAME', ${phpString(dbUser)});
+define('PASSWORD', ${phpString(dbPassword)});
+define('DB', ${phpString(dbName)});
+
+$adminPassword = 'e2e-admin-password';
+
+try {
+  $dbh = new PDO('mysql:host=' . SERVER . ';dbname=' . DB, USERNAME, PASSWORD, array(PDO::ATTR_PERSISTENT => false));
+} catch (PDOException $e) {
+  die($e->getMessage());
+}
+?>
+`,
+  'utf8'
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,8 @@ import { viteStaticCopy } from 'vite-plugin-static-copy';
 import htmlIncludes from './vite-plugin-html-includes.js';
 import path from 'path';
 
+const phpProxyPort = process.env.E2E_PHP_PORT || '2461';
+
 export default defineConfig({
   root: 'src',
   base: '/',
@@ -163,7 +165,7 @@ export default defineConfig({
     proxy: {
       // Proxy API requests to PHP backend
       '/api': {
-        target: 'http://localhost:2461',
+        target: `http://localhost:${phpProxyPort}`,
         changeOrigin: true,
         secure: false
       }


### PR DESCRIPTION
## Summary
- add Playwright config and scripts for a create -> vote -> results happy-path E2E
- create and tear down an isolated MySQL `rcv_e2e` database for browser tests
- add inert `data-testid` hooks to the AngularJS templates for stable E2E selectors
- harden the harness for future CI use with run-specific DB names, ports, and cache directories
- scope the test to active views/forms and assert against dedicated candidate-name and winner elements to reduce flake risk

## Verification
- `npm run test:e2e`
- `npm test`
- `npm run build`
- ran the Playwright happy-path 10 times in two concurrent batches of 5; all 10 passed
