### PR TITLE
Add Playwright auth E2E coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ composer.lock
 # PHPUnit
 .phpunit.result.cache
 
+# Playwright
+test-results/
+playwright-report/
+
 # OS / Editor Files
 .DS_Store
 Thumbs.db

--- a/src/pages/profile.html
+++ b/src/pages/profile.html
@@ -1,10 +1,10 @@
-<div ng-show="activeLink == 'profile'" class="panel panel-default">
+<div ng-show="activeLink == 'profile'" class="panel panel-default" data-testid="profile-view">
   <div class="panel-body">
     <h1>Profile</h1>
-    <a href="#" ng-click="signOut()" class="pull-right btn btn-info" style="margin-top: -40px"
+    <a href="#" ng-click="signOut()" class="pull-right btn btn-info" style="margin-top: -40px" data-testid="sign-out"
       >Sign out</a
     >
-    <h3 ng-show="user.name">Name: {{user.name}}</h3>
+    <h3 ng-show="user.name" data-testid="profile-name">Name: {{user.name}}</h3>
     <div ng-show="!ballotsLoaded" style="margin-top: 20px; text-align: center">
       <i class="fa fa-spinner fa-spin fa-2x"></i>
     </div>

--- a/src/pages/register.html
+++ b/src/pages/register.html
@@ -1,4 +1,4 @@
-      <div ng-show="activeLink == 'register'" class="panel panel-default">
+      <div ng-show="activeLink == 'register'" class="panel panel-default" data-testid="register-view">
         <div class="panel-body">
           <h1>Register</h1>
           <div class="row hidden" ng-hide="user.id">
@@ -95,12 +95,13 @@
           <div class="row" ng-hide="user.id">
             <div class="col-sm-6">
               <h2>Login</h2>
-              <form class="reg-login col-md-7" ng-submit="loginForm()">
+              <form class="reg-login col-md-7" ng-submit="loginForm()" data-testid="login-form">
                 <div class="form-group">
                   <label for="login-username">Username</label>
                   <input
                     class="form-control"
                     id="login-username"
+                    data-testid="login-username-input"
                     ng-model="login.username"
                     ng-change="loginError = false"
                   />
@@ -110,28 +111,29 @@
                   <input
                     class="form-control"
                     id="login-password"
+                    data-testid="login-password-input"
                     type="password"
                     ng-model="login.password"
                     ng-change="loginError = false"
                   />
                 </div>
-                <div class="alert alert-danger" ng-show="loginError">
+                <div class="alert alert-danger" ng-show="loginError" data-testid="login-error">
                   Incorrect username and/or password.
                 </div>
                 <div class="form-group">
                   <label>
-                    Remember me (30 days) <input type="checkbox" ng-model="login.remember" />
+                    Remember me (30 days) <input type="checkbox" ng-model="login.remember" data-testid="login-remember-input" />
                   </label>
                 </div>
-                <button type="submit" class="btn btn-primary">Login</button>
+                <button type="submit" class="btn btn-primary" data-testid="login-submit">Login</button>
               </form>
             </div>
             <div class="col-sm-6">
               <h2>Create New Account</h2>
-              <div class="reg-login col-md-7">
+              <div class="reg-login col-md-7" data-testid="register-form">
                 <div class="form-group">
                   <label for="create-username">Username</label>
-                  <input class="form-control" id="create-username" ng-model="newAccount.username" />
+                  <input class="form-control" id="create-username" data-testid="register-username-input" ng-model="newAccount.username" />
                 </div>
                 <div class="form-group">
                   <label for="create-password"
@@ -142,14 +144,15 @@
                   <input
                     class="form-control"
                     id="create-password"
+                    data-testid="register-password-input"
                     type="password"
                     ng-model="newAccount.password"
                   />
                 </div>
-                <div class="btn btn-primary" ng-click="createNewAccount()">Create</div>
+                <div class="btn btn-primary" ng-click="createNewAccount()" data-testid="register-submit">Create</div>
               </div>
             </div>
           </div>
-          <div ng-show="user.name">Thank you for signing in as {{user.name}}.</div>
+          <div ng-show="user.name" data-testid="signed-in-message">Thank you for signing in as {{user.name}}.</div>
         </div>
       </div>

--- a/test/e2e/auth.spec.js
+++ b/test/e2e/auth.spec.js
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test';
+
+test('registers, signs out, rejects a bad password, and logs back in', async ({ page }) => {
+  await page.route(/^https?:\/\/(?!(127\.0\.0\.1|localhost)(:\d+)?\/).*/, (route) => {
+    route.abort();
+  });
+
+  const suffix = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+  const username = `e2euser${suffix}`;
+  const password = `pass-${suffix}`;
+
+  await page.goto('/register');
+  const registerView = page.getByTestId('register-view');
+  await expect(registerView).toBeVisible();
+
+  await registerView.getByTestId('register-username-input').fill(username);
+  await registerView.getByTestId('register-password-input').fill(password);
+  await registerView.getByTestId('register-submit').click();
+
+  const createView = page.getByTestId('create-view');
+  await expect(createView).toBeVisible();
+  await expect(createView).toContainText(`Created By ${username}`);
+
+  await page.getByRole('link', { name: /profile/i }).click();
+  const profileView = page.getByTestId('profile-view');
+  await expect(profileView).toBeVisible();
+  await expect(profileView.getByTestId('profile-name')).toHaveText(`Name: ${username}`);
+
+  await profileView.getByTestId('sign-out').click();
+  await expect(page.getByRole('link', { name: /^register/i })).toBeVisible();
+
+  await page.goto('/register');
+  await registerView.getByTestId('login-username-input').fill(username);
+  await registerView.getByTestId('login-password-input').fill(`${password}-wrong`);
+  await registerView.getByTestId('login-submit').click();
+  await expect(registerView.getByTestId('login-error')).toBeVisible();
+
+  await registerView.getByTestId('login-password-input').fill(password);
+  await registerView.getByTestId('login-remember-input').check();
+  await registerView.getByTestId('login-submit').click();
+
+  await expect(profileView).toBeVisible();
+  await expect(profileView.getByTestId('profile-name')).toHaveText(`Name: ${username}`);
+
+  await page.reload();
+  await expect(registerView.getByTestId('signed-in-message')).toHaveText(
+    `Thank you for signing in as ${username}.`
+  );
+  await page.getByRole('link', { name: /profile/i }).click();
+  await expect(profileView).toBeVisible();
+  await expect(profileView.getByTestId('profile-name')).toHaveText(`Name: ${username}`);
+});


### PR DESCRIPTION
## Summary
- add Playwright coverage for local account registration, sign-out, failed login, successful login, and remembered-session restoration
- add stable test IDs for register/login/profile auth selectors
- ignore generated Playwright output directories

## Testing
- npm run test:e2e
- npx playwright test --repeat-each=5
- E2E_RUN_ID=authstress_a npx playwright test --repeat-each=3 and E2E_RUN_ID=authstress_b npx playwright test --repeat-each=3 concurrently