### PR TITLE
Add Playwright secure-code E2E coverage

### DIFF
--- a/src/pages/create.html
+++ b/src/pages/create.html
@@ -51,7 +51,7 @@
       <div class="form-group">
         <label
           >More Options
-          <input type="checkbox" ng-model="advancedOptions" />
+          <input type="checkbox" ng-model="advancedOptions" data-testid="advanced-options-toggle" />
         </label>
       </div>
       <div ng-show="advancedOptions" ng-init="activeSection=null">
@@ -296,7 +296,7 @@
           <div class="form-group" ng-show="user.name">
             <label>
               Secure Ballot (voters provided codes):
-              <input type="checkbox" ng-model="ballot.isSecure" ng-change="onSecureToggle()" />
+              <input type="checkbox" ng-model="ballot.isSecure" ng-change="onSecureToggle()" data-testid="secure-ballot-toggle" />
             </label>
             <small ng-show="ballot.isSecure" class="text-muted">
               Secure ballots use system-generated codes for verified voting.
@@ -310,6 +310,7 @@
               min="1"
               max="500"
               class="form-control"
+              data-testid="secure-code-count-input"
               style="max-width: 200px"
               placeholder="e.g. 25"
             /><small class="text-muted">more may be added at any time</small>

--- a/src/pages/vote.html
+++ b/src/pages/vote.html
@@ -32,6 +32,7 @@
     <div
       ng-if="candidates && ballot.isSecure && !secureCodeValid"
       ng-hide="thanks || deviceAlreadyVoted"
+      data-testid="secure-code-gate"
     >
       <h1 data-testid="vote-ballot-title">Ballot: {{ballot.name}}</h1>
       <h3>Enter your voter code to proceed</h3>
@@ -41,14 +42,15 @@
             type="text"
             ng-model="secure.voterCode"
             class="form-control voter-code"
+            data-testid="secure-code-input"
             placeholder="ABC123"
             maxlength="6"
             autocomplete="off"
             style="font-size: 24px; text-align: center; letter-spacing: 4px"
           />
-          <span ng-show="errors.secureCode" class="text-danger">{{errors.secureCode}}</span>
+          <span ng-show="errors.secureCode" class="text-danger" data-testid="secure-code-error">{{errors.secureCode}}</span>
         </div>
-        <button type="submit" class="btn btn-success">Submit Code</button>
+        <button type="submit" class="btn btn-success" data-testid="secure-code-submit">Submit Code</button>
       </form>
     </div>
     <div

--- a/test/e2e/db.mjs
+++ b/test/e2e/db.mjs
@@ -66,6 +66,23 @@ async function schemaTablesSql() {
   return schema.slice(start);
 }
 
+function e2eSeedSql() {
+  // Secure-code input normalizes 0 -> o and 1 -> i, so avoid 0/1 here.
+  return `
+INSERT INTO random_codes (code) VALUES
+('ABC234'),
+('DEF456'),
+('GHI789'),
+('JKL234'),
+('MNO345'),
+('PQR678'),
+('STU923'),
+('VWX234'),
+('YZA567'),
+('BCD892');
+`;
+}
+
 export async function setupDatabase() {
   const dbName = quoteIdent(config.dbName);
   const tables = await schemaTablesSql();
@@ -77,6 +94,7 @@ GRANT ALL PRIVILEGES ON ${dbName}.* TO ${sqlString(config.appUser)}@${sqlString(
 FLUSH PRIVILEGES;
 USE ${dbName};
 ${tables}
+${e2eSeedSql()}
 `);
 }
 

--- a/test/e2e/secure-code.spec.js
+++ b/test/e2e/secure-code.spec.js
@@ -1,0 +1,90 @@
+import { expect, test } from '@playwright/test';
+
+test('creates a secure ballot, validates a voter code, and renders results', async ({ page }) => {
+  await page.route(/^https?:\/\/(?!(127\.0\.0\.1|localhost)(:\d+)?\/).*/, (route) => {
+    route.abort();
+  });
+
+  const suffix = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+  const username = `secureuser${suffix}`;
+  const password = `pass-${suffix}`;
+  const shortcode = `sec${suffix}`.slice(0, 16);
+  const ballotName = `Secure E2E ${suffix}`;
+
+  await page.goto('/register');
+  const registerView = page.getByTestId('register-view');
+  await expect(registerView).toBeVisible();
+  const addUserResponsePromise = page.waitForResponse((response) =>
+    response.url().includes('/api/add-user.php') && response.request().method() === 'POST'
+  );
+  await registerView.getByTestId('register-username-input').fill(username);
+  await registerView.getByTestId('register-password-input').fill(password);
+  await registerView.getByTestId('register-submit').click();
+  const addUserResponse = await addUserResponsePromise;
+  const user = await addUserResponse.json();
+  const userId = user.id;
+
+  const createView = page.getByTestId('create-view');
+  await expect(createView).toBeVisible();
+  await createView.getByTestId('ballot-name-input').fill(ballotName);
+  await createView.getByTestId('ballot-key-input').fill(shortcode);
+  await createView.getByTestId('advanced-options-toggle').check();
+  await createView.getByText('Voter Settings').click();
+  await createView.getByTestId('secure-ballot-toggle').check();
+  await createView.getByTestId('secure-code-count-input').fill('1');
+
+  const newBallotResponsePromise = page.waitForResponse((response) =>
+    response.url().includes('/api/new-ballot.php') && response.request().method() === 'POST'
+  );
+  await createView.getByTestId('ballot-submit').click();
+  const newBallotResponse = await newBallotResponsePromise;
+  const ballotId = Number(await newBallotResponse.text());
+  expect(ballotId).toBeGreaterThan(0);
+
+  const entryInput = createView.getByTestId('entry-input');
+  await expect(entryInput).toBeVisible();
+  for (const entry of ['Ada', 'Grace', 'Katherine']) {
+    await entryInput.fill(entry);
+    await createView.getByTestId('entry-add').click();
+  }
+  await createView.getByTestId('entries-submit').click();
+  await expect(createView.getByTestId('ballot-created')).toBeVisible();
+
+  const codesResponse = await page.request.post('/api/get-ballot-codes.php', {
+    data: {
+      ballotId,
+      createdBy: userId
+    }
+  });
+  expect(codesResponse.ok()).toBeTruthy();
+  const codesPayload = await codesResponse.json();
+  expect(codesPayload.codes).toHaveLength(1);
+  const voterCode = codesPayload.codes[0].code;
+
+  await page.goto(`/vote#${shortcode}`);
+  const voteView = page.getByTestId('vote-view');
+  const secureGate = voteView.getByTestId('secure-code-gate');
+  await expect(secureGate.getByTestId('vote-ballot-title')).toContainText(ballotName);
+
+  await secureGate.getByTestId('secure-code-input').fill('xxxxxx');
+  await secureGate.getByTestId('secure-code-submit').click();
+  await expect(secureGate.getByTestId('secure-code-error')).toHaveText('This code is not valid');
+
+  await secureGate.getByTestId('secure-code-input').fill(voterCode);
+  await secureGate.getByTestId('secure-code-submit').click();
+
+  const ballotForm = voteView.getByTestId('vote-ballot-form');
+  await expect(ballotForm.getByTestId('vote-ballot-title')).toContainText(ballotName);
+  const candidates = ballotForm.getByTestId('vote-candidate');
+  await expect(candidates).toHaveCount(3);
+  const firstChoice = await candidates.first().getByTestId('vote-candidate-name').innerText();
+  await ballotForm.getByTestId('vote-submit').click();
+
+  await expect(voteView.getByTestId('vote-thanks')).toBeVisible();
+  await voteView.getByTestId('results-link').click();
+
+  const resultsView = page.getByTestId('results-view');
+  const finalResults = resultsView.getByTestId('results-final');
+  await expect(finalResults).toBeVisible();
+  await expect(finalResults.getByTestId('results-winner-name')).toHaveText(firstChoice);
+});


### PR DESCRIPTION
## Summary
- add a stacked Playwright E2E test for secure-code voting
- seed an E2E-only pool of random voter codes, avoiding 0/1 because secure-code input normalizes 0 -> o and 1 -> i
- add stable selectors for secure ballot creation controls and the secure-code gate

## Relationship to PR #53
This PR is intentionally stacked on top of #53, branch codex/playwright-auth-e2e. It reuses the auth/register selectors added there so the secure-code test does not rely on brittle IDs or text-only selectors.

Suggested review order:
1. Review/merge #53 first.
2. Then retarget or rebase this PR onto master if GitHub does not do that automatically.

## Testing
- npm run test:e2e
- npx playwright test --repeat-each=3